### PR TITLE
chore: nonexistent module -Axxu

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -16,7 +16,6 @@ client_script 'client/main.lua'
 server_script 'server/main.lua'
 
 modules {
-	'qbx_core:core',
 	'qbx_core:playerdata',
 	'qbx_core:utils'
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -36,7 +36,7 @@ RegisterNetEvent('qb-vehiclekeys:server:AcquireVehicleKeys', function(plate)
 end)
 
 RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
-    local player = QBX.Functions.GetPlayer(source)
+    local player = exports.qbx_core:GetPlayer(source)
     if not player then return end
     if not (itemName == "lockpick" or itemName == "advancedlockpick") then return end
     if player.Functions.RemoveItem(itemName, 1) then
@@ -49,7 +49,7 @@ RegisterNetEvent('qb-vehiclekeys:server:setVehLockState', function(vehNetId, sta
 end)
 
 lib.callback.register('qbx-vehiclekeys:server:getVehicleKeys', function(source)
-    local citizenid = QBX.Functions.GetPlayer(source).PlayerData.citizenid
+    local citizenid = exports.qbx_core:GetPlayer(source).PlayerData.citizenid
     local keysList = {}
     for plate, citizenids in pairs (vehicleList) do
         if citizenids[citizenid] then
@@ -63,7 +63,7 @@ end)
 ----   Functions   ----
 -----------------------
 function GiveKeys(id, plate)
-    local citizenid = QBX.Functions.GetPlayer(id).PlayerData.citizenid
+    local citizenid = exports.qbx_core:GetPlayer(id).PlayerData.citizenid
 
     if not vehicleList[plate] then vehicleList[plate] = {} end
     vehicleList[plate][citizenid] = true
@@ -73,7 +73,7 @@ function GiveKeys(id, plate)
 end
 
 function RemoveKeys(id, plate)
-    local citizenid = QBX.Functions.GetPlayer(id).PlayerData.citizenid
+    local citizenid = exports.qbx_core:GetPlayer(id).PlayerData.citizenid
 
     if vehicleList[plate] and vehicleList[plate][citizenid] then
         vehicleList[plate][citizenid] = nil
@@ -83,7 +83,7 @@ function RemoveKeys(id, plate)
 end
 
 function HasKeys(id, plate)
-    local citizenid = QBX.Functions.GetPlayer(id).PlayerData.citizenid
+    local citizenid = exports.qbx_core:GetPlayer(id).PlayerData.citizenid
     if vehicleList[plate] and vehicleList[plate][citizenid] then
         return true
     end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
removes nonexistent module so script doesn't warn on startup.
fixed https://github.com/Qbox-project/qbx_vehiclekeys/issues/15 attempt to index a nil value (global 'QBX')
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
