### PR TITLE
GiveKeys export

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -69,6 +69,7 @@ function GiveKeys(id, plate)
     exports.qbx_core:Notify(id, Lang:t('notify.keys_taken'))
     TriggerClientEvent('qb-vehiclekeys:client:AddKeys', id, plate)
 end
+exports('GiveKeys', GiveKeys)
 
 function RemoveKeys(id, plate)
     local citizenid = exports.qbx_core:GetPlayer(id).PlayerData.citizenid


### PR DESCRIPTION
## Description

Adds an export to allow the server side to Give keys
necessary to fix /car in [qbx_core #205](https://github.com/Qbox-project/qbx_core/pull/205)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
