### PR TITLE
fix: typos in config and client main

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -409,11 +409,11 @@ function LockpickFinishCallback(success)
     end
 
     if usingAdvanced then
-        if chance <= Config.removeLockpickAdvanced[GetVehicleClass(vehicle)] then
+        if chance <= Config.removeAdvancedLockpickChance[GetVehicleClass(vehicle)] then
             TriggerServerEvent("qb-vehiclekeys:server:breakLockpick", "advancedlockpick")
         end
     else
-        if chance <= Config.removeLockpickNormal[GetVehicleClass(vehicle)] then
+        if chance <= Config.removeNormalLockpickChance[GetVehicleClass(vehicle)] then
             TriggerServerEvent("qb-vehiclekeys:server:breakLockpick", "lockpick")
         end
     end

--- a/config.lua
+++ b/config.lua
@@ -33,7 +33,7 @@ Config = {
         [21] = 0.5, -- Trains
         [22] = 0.5, -- Open Wheel
     },
-    removeLockpickAdvanced = { -- Chance to remove advanced lockpick on fail by vehicle class
+    removeAdvancedLockpickChance = { -- Chance to remove advanced lockpick on fail by vehicle class
         [0] = 0.5, -- Compacts
         [1] = 0.5, -- Sedans
         [2] = 0.5, -- SUVs


### PR DESCRIPTION
## Description

There was a typo in the config for the removal of the lockpick, so I fixed it and also updated the advanced one to match the normal lockpick name

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
