### PR TITLE
fix: config variable typo

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -55,7 +55,7 @@ CreateThread(function()
                                 isTakingKeys = false
                             end
                         end
-                    elseif config.lockNPCDrivingCars then
+                    elseif config.lockNPCDrivenCars then
                         TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(entering), 2)
                     else
                         TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(entering), 1)


### PR DESCRIPTION
## Description

Variable in the configuration is lockNPCDrivenCars not lockNPCDrivingCars. This fixes the typo allowing NPC driven vehicles to be locked as desired.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
