### PR TITLE
fix: Garage vehicles spawn feat: statebag of keys

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -52,7 +52,7 @@ exports('HasKeys', public.hasKeys)
 function public.isBlacklistedWeapon()
     local weapon = GetSelectedPedWeapon(cache.ped)
 
-    for _, v in pairs(config.noCarjackWeapons) do
+    for _, v in ipairs(config.noCarjackWeapons) do
         if weapon == joaat(v) then return true end
     end
 end

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -52,8 +52,8 @@ exports('HasKeys', public.hasKeys)
 function public.isBlacklistedWeapon()
     local weapon = GetSelectedPedWeapon(cache.ped)
 
-    for _, v in ipairs(config.noCarjackWeapons) do
-        if weapon == joaat(v) then return true end
+    for _, w in ipairs(config.noCarjackWeapons) do
+        if weapon == joaat(w) then return true end
     end
 end
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -205,7 +205,7 @@ function public.lockpickDoor(isAdvancedLockedpick, maxDistance, customChallenge)
         or GetVehicleDoorLockStatus(vehicle) < 2                            -- the vehicle is locked
     then return end
 
-    lockpickingSemaphore = lockpickingSemaphore + 1
+    lockpickingSemaphore += 1
     if lockpickingSemaphore > 1 then return end
 
     CreateThread(function()

--- a/client/main.lua
+++ b/client/main.lua
@@ -431,7 +431,7 @@ RegisterNetEvent('qb-vehiclekeys:client:GiveKeys', function(id)
                         GetPlayerServerId(NetworkGetPlayerIndexFromPed(occupant)), targetPlate)
                 end
             else     -- Give keys to closest player
-                local playerId, _, _ = lib.getClosestPlayer(GetEntityCoords(cache.ped), 3, false)
+                local playerId = lib.getClosestPlayer(GetEntityCoords(cache.ped), 3, false)
                 giveKeys(playerId, targetPlate)
             end
         end

--- a/client/main.lua
+++ b/client/main.lua
@@ -4,17 +4,28 @@
 
 local config = require 'config.client'
 local functions = require 'client.functions'
-local lockpickDoor, attemptPoliceAlert, isBlacklistedWeapon, isBlacklistedVehicle in functions
+local sharedFunction = require 'shared.functions'
+
+--#region spread functions
+local hasKeys,
+    lockpickDoor,
+    attemptPoliceAlert,
+    isBlacklistedWeapon,
+    isBlacklistedVehicle =
+    functions.hasKeys,
+    functions.lockpickDoor,
+    functions.attemptPoliceAlert,
+    functions.isBlacklistedWeapon,
+    functions.isBlacklistedVehicle
+
+local getHash = sharedFunction.getHash
+--#endregion
 
 -----------------------
 ----   Variables   ----
 -----------------------
 
-local KeysList = {}
-local isTakingKeys = false
-local isCarjacking = false
-local canCarjack = true
-local isHotwiring = false
+local isTakingKeys, isCarjacking, isHotwiring, canCarjack = false, false, false, true
 
 -----------------------
 ----   Functions   ----
@@ -22,23 +33,13 @@ local isHotwiring = false
 
 local function giveKeys(id, plate)
     local distance = #(GetEntityCoords(cache.ped) - GetEntityCoords(GetPlayerPed(GetPlayerFromServerId(id))))
+
     if distance < 1.5 and distance > 0.0 then
         TriggerServerEvent('qb-vehiclekeys:server:GiveVehicleKeys', id, plate)
     else
         exports.qbx_core:Notify(locale("notify.not_near"), 'error')
     end
 end
-
-local function getKeys()
-    lib.callback('qbx-vehiclekeys:server:getVehicleKeys', false, function(keysList)
-        KeysList = keysList
-    end)
-end
-
-local function hasKeys(plate)
-    return KeysList[plate]
-end
-exports('HasKeys', hasKeys)
 
 local function getVehicleInDirection(coordFromOffset, coordToOffset)
     local coordFrom = GetOffsetFromEntityInWorldCoords(cache.ped, coordFromOffset.x, coordFromOffset.y, coordFromOffset
@@ -77,7 +78,7 @@ local function areKeysJobShared(veh)
     for job, v in pairs(config.sharedKeys) do
         if job == QBX.PlayerData.job.name then
             if config.sharedKeys[job].requireOnduty and not QBX.PlayerData.job.onduty then return false end
-            for _, vehicle in pairs(v.vehicles) do
+            for _, vehicle in ipairs(v.vehicles) do
                 if string.upper(vehicle) == string.upper(vehName) then
                     if not hasKeys(vehPlate) then
                         TriggerServerEvent("qb-vehiclekeys:server:AcquireVehicleKeys", vehPlate)
@@ -164,17 +165,7 @@ end
 local function hotwire(vehicle, plate)
     local hotwireTime = math.random(config.minHotwireTime, config.maxHotwireTime)
     isHotwiring = true
-    SetVehicleAlarm(vehicle, true)
-    SetVehicleAlarmTimeLeft(vehicle, 2)
 
-    SetTimeout(hotwireTime * 2, function()
-        if not DoesEntityExist(vehicle) then return end
-        if not IsEntityAVehicle(vehicle) then return end
-        if isHotwiring then return end
-        if IsVehicleAlarmActivated(vehicle) then
-            SetVehicleAlarm(vehicle, false)
-        end
-    end)
     if lib.progressCircle({
         duration = hotwireTime,
         label = locale("progress.searching_keys"),
@@ -191,17 +182,15 @@ local function hotwire(vehicle, plate)
             combat = true,
         }
     }) then
-        StopAnimTask(cache.ped, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0)
         if (math.random() <= config.hotwireChance[GetVehicleClass(vehicle)]) then
             TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
         else
             TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
-            exports.qbx_core:Notify(locale("notify.failed_lockedpick"), 'error')
+            exports.qbx_core:Notify(locale("notify.failed_keys"), 'error')
         end
         Wait(config.timeBetweenHotwires)
         isHotwiring = false
     else
-        StopAnimTask(cache.ped, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0)
         isHotwiring = false
     end
     SetTimeout(10000, function()
@@ -217,14 +206,14 @@ local function carjackVehicle(target)
     lib.requestAnimDict('mp_am_hold_up')
     local vehicle = GetVehiclePedIsUsing(target)
     local occupants = getPedsInVehicle(vehicle)
-    for p = 1, #occupants do
-        local ped = occupants[p]
+    for _, occupant in ipairs(occupants) do
         CreateThread(function()
-            TaskPlayAnim(ped, "mp_am_hold_up", "holdup_victim_20s", 8.0, -8.0, -1, 49, 0, false, false, false)
-            PlayPain(ped, 6, 0)
+            TaskPlayAnim(occupant, "mp_am_hold_up", "holdup_victim_20s", 8.0, -8.0, -1, 49, 0, false, false, false)
+            PlayPain(occupant, 6, 0)
         end)
         Wait(math.random(200, 500))
     end
+
     -- Cancel progress bar if: Ped dies during robbery, car gets too far away
     CreateThread(function()
         while isCarjacking do
@@ -248,12 +237,11 @@ local function carjackVehicle(target)
     }) then
         local hasWeapon, weaponHash = GetCurrentPedWeapon(cache.ped, true)
         if hasWeapon and isCarjacking then
-            local carjackChance
+            local carjackChance = 0.5
             if config.carjackChance[tostring(GetWeapontypeGroup(weaponHash))] then
                 carjackChance = config.carjackChance[tostring(GetWeapontypeGroup(weaponHash))]
-            else
-                carjackChance = 0.5
             end
+
             if math.random() <= carjackChance then
                 local plate = qbx.getVehiclePlate(vehicle)
                 for p = 1, #occupants do
@@ -298,7 +286,6 @@ CreateThread(function()
         if LocalPlayer.state.isLoggedIn then
             sleep = 100
 
-
             local entering = GetVehiclePedIsTryingToEnter(cache.ped)
             local carIsImmune = false
             if entering ~= 0 and not isBlacklistedVehicle(entering) then
@@ -306,8 +293,8 @@ CreateThread(function()
                 local plate = qbx.getVehiclePlate(entering)
 
                 local driver = GetPedInVehicleSeat(entering, -1)
-                for _, veh in ipairs(config.immuneVehicles) do
-                    if GetEntityModel(entering) == joaat(veh) then
+                for _, vehicle in ipairs(config.immuneVehicles) do
+                    if GetEntityModel(entering) == getHash(vehicle) then
                         carIsImmune = true
                     end
                 end
@@ -329,10 +316,8 @@ CreateThread(function()
                                 },
                             }) then
                                 TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
-                                isTakingKeys = false
-                            else
-                                isTakingKeys = false
                             end
+                            isTakingKeys = false
                         end
                     elseif config.lockNPCDrivenCars then
                         TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(entering), 2)
@@ -342,7 +327,7 @@ CreateThread(function()
 
                         --Make passengers flee
                         local pedsInVehicle = getPedsInVehicle(entering)
-                        for _, pedInVehicle in pairs(pedsInVehicle) do
+                        for _, pedInVehicle in ipairs(pedsInVehicle) do
                             if pedInVehicle ~= GetPedInVehicleSeat(entering, -1) then
                                 makePedFlee(pedInVehicle)
                             end
@@ -363,7 +348,11 @@ CreateThread(function()
                 sleep = 1000
                 local plate = qbx.getVehiclePlate(cache.vehicle)
 
-                if GetPedInVehicleSeat(cache.vehicle, -1) == cache.ped and not hasKeys(plate) and not isBlacklistedVehicle(cache.vehicle) and not areKeysJobShared(cache.vehicle) then
+                if GetPedInVehicleSeat(cache.vehicle, -1) == cache.ped
+                    and not hasKeys(plate)
+                    and not isBlacklistedVehicle(cache.vehicle)
+                    and not areKeysJobShared(cache.vehicle)
+                then
                     sleep = 0
 
                     local vehiclePos = GetOffsetFromEntityInWorldCoords(cache.vehicle, 0.0, 1.0, 0.5)
@@ -380,15 +369,15 @@ CreateThread(function()
                 local aiming, target = GetEntityPlayerIsFreeAimingAt(cache.playerId)
                 if aiming and (target ~= nil and target ~= 0) then
                     if DoesEntityExist(target) and IsPedInAnyVehicle(target, false) and not IsEntityDead(target) and not IsPedAPlayer(target) then
-                        local targetveh = GetVehiclePedIsIn(target, false)
-                        for _, veh in ipairs(config.immuneVehicles) do
-                            if GetEntityModel(targetveh) == joaat(veh) then
+                        local targetVehicle = GetVehiclePedIsIn(target, false)
+                        for _, vehicle in ipairs(config.immuneVehicles) do
+                            if GetEntityModel(targetVehicle) == getHash(vehicle) then
                                 carIsImmune = true
                             end
                         end
-                        if GetPedInVehicleSeat(targetveh, -1) == target and not isBlacklistedWeapon() then
-                            local pos = GetEntityCoords(cache.ped, true)
-                            local targetpos = GetEntityCoords(target, true)
+                        if GetPedInVehicleSeat(targetVehicle, -1) == target and not isBlacklistedWeapon() then
+                            local pos = GetEntityCoords(cache.ped)
+                            local targetpos = GetEntityCoords(target)
                             if #(pos - targetpos) < 5.0 and not carIsImmune then
                                 carjackVehicle(target)
                             end
@@ -415,47 +404,11 @@ RegisterCommand('engine', function()
     TriggerEvent("qb-vehiclekeys:client:ToggleEngine")
 end, false)
 
-AddEventHandler('onResourceStart', function(resourceName)
-	if resourceName == cache.resource and QBX.PlayerData ~= {} then
-		getKeys()
-	end
-end)
-
--- Handles state right when the player selects their character and location.
-RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
-    getKeys()
-end)
-
--- Resets state on logout, in case of character change.
-RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
-    KeysList = {}
-end)
-
-RegisterNetEvent('qb-vehiclekeys:client:AddKeys', function(plate)
-    KeysList[plate] = true
-
-    if cache.vehicle then
-        local vehicleplate = qbx.getVehiclePlate(cache.vehicle)
-
-        if plate == vehicleplate then
-            SetVehicleEngineOn(cache.vehicle, false, false, false)
-        end
-    end
-end)
-
-RegisterNetEvent('qb-vehiclekeys:client:RemoveKeys', function(plate)
-    KeysList[plate] = nil
-end)
-
 RegisterNetEvent('qb-vehiclekeys:client:ToggleEngine', function()
     local vehicle = cache.vehicle
     if vehicle and hasKeys(qbx.getVehiclePlate(vehicle)) then
         local engineOn = GetIsVehicleEngineRunning(vehicle)
-        if engineOn then
-            SetVehicleEngineOn(vehicle, false, false, true)
-        else
-            SetVehicleEngineOn(vehicle, true, false, true)
-        end
+        SetVehicleEngineOn(vehicle, not engineOn, false, true)
     end
 end)
 
@@ -464,22 +417,23 @@ RegisterNetEvent('qb-vehiclekeys:client:GiveKeys', function(id)
 
     if targetVehicle then
         local targetPlate = qbx.getVehiclePlate(targetVehicle)
-        if hasKeys(targetPlate) then
-            if id and type(id) == "number" then -- Give keys to specific ID
-                giveKeys(id, targetPlate)
-            else
-                if IsPedSittingInVehicle(cache.ped, targetVehicle) then -- Give keys to everyone in vehicle
-                    local otherOccupants = getOtherPlayersInVehicle(targetVehicle)
-                    for p = 1, #otherOccupants do
-                        TriggerServerEvent('qb-vehiclekeys:server:GiveVehicleKeys', GetPlayerServerId(NetworkGetPlayerIndexFromPed(otherOccupants[p])), targetPlate)
-                    end
-                else -- Give keys to closest player
-                    local playerId, _, _ = lib.getClosestPlayer(GetEntityCoords(cache.ped), 3, false)
-                    giveKeys(playerId, targetPlate)
-                end
-            end
+
+        if not hasKeys(targetPlate) then return exports.qbx_core:Notify(locale("notify.no_keys"), 'error') end
+
+        if id and type(id) == "number" then     -- Give keys to specific ID
+            giveKeys(id, targetPlate)
         else
-            exports.qbx_core:Notify(locale("notify.no_keys"), 'error')
+            if IsPedSittingInVehicle(cache.ped, targetVehicle) then     -- Give keys to everyone in vehicle
+                local otherOccupants = getOtherPlayersInVehicle(targetVehicle)
+
+                for occupant in otherOccupants do
+                    TriggerServerEvent('qb-vehiclekeys:server:GiveVehicleKeys',
+                        GetPlayerServerId(NetworkGetPlayerIndexFromPed(occupant)), targetPlate)
+                end
+            else     -- Give keys to closest player
+                local playerId, _, _ = lib.getClosestPlayer(GetEntityCoords(cache.ped), 3, false)
+                giveKeys(playerId, targetPlate)
+            end
         end
     end
 end)
@@ -489,7 +443,20 @@ RegisterNetEvent('lockpicks:UseLockpick', function(isAdvanced)
 end)
 
 -- Backwards Compatibility ONLY -- Remove at some point --
+RegisterNetEvent('qb-vehiclekeys:client:AddKeys', function(plate)
+    TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
+    if cache.vehicle and plate == qbx.getVehiclePlate(cache.vehicle) then
+        SetVehicleEngineOn(cache.vehicle, false, false, false)
+    end
+end)
+
 RegisterNetEvent('vehiclekeys:client:SetOwner', function(plate)
     TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
 end)
 -- Backwards Compatibility ONLY -- Remove at some point --
+
+AddEventHandler('onResourceStart', function(resourceName)
+    if resourceName == GetCurrentResourceName() then
+        TriggerServerEvent('qbx-vehiclekeys:server:setPlayerKeys')
+    end
+end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -6,26 +6,24 @@ local config = require 'config.client'
 local functions = require 'client.functions'
 local sharedFunction = require 'shared.functions'
 
---#region spread functions
-local hasKeys,
-    lockpickDoor,
-    attemptPoliceAlert,
-    isBlacklistedWeapon,
-    isBlacklistedVehicle =
-    functions.hasKeys,
-    functions.lockpickDoor,
-    functions.attemptPoliceAlert,
-    functions.isBlacklistedWeapon,
-    functions.isBlacklistedVehicle
+-- #region spread imported functions
 
-local getHash = sharedFunction.getHash
---#endregion
+local hasKeys = functions.hasKeys
+local lockpickDoor = functions.lockpickDoor
+local attemptPoliceAlert = functions.attemptPoliceAlert
+local isBlacklistedWeapon = functions.isBlacklistedWeapon
+local isBlacklistedVehicle = functions.isBlacklistedVehicle
+
+-- #endregion
 
 -----------------------
 ----   Variables   ----
 -----------------------
 
-local isTakingKeys, isCarjacking, isHotwiring, canCarjack = false, false, false, true
+local isTakingKeys = false
+local isCarjacking = false
+local isHotwiring = false
+local canCarjack = true
 
 -----------------------
 ----   Functions   ----
@@ -189,10 +187,8 @@ local function hotwire(vehicle, plate)
             exports.qbx_core:Notify(locale("notify.failed_keys"), 'error')
         end
         Wait(config.timeBetweenHotwires)
-        isHotwiring = false
-    else
-        isHotwiring = false
     end
+
     SetTimeout(10000, function()
         attemptPoliceAlert("steal")
     end)
@@ -294,7 +290,7 @@ CreateThread(function()
 
                 local driver = GetPedInVehicleSeat(entering, -1)
                 for _, vehicle in ipairs(config.immuneVehicles) do
-                    if GetEntityModel(entering) == getHash(vehicle) then
+                    if GetEntityModel(entering) == joaat(vehicle) then
                         carIsImmune = true
                     end
                 end
@@ -371,7 +367,7 @@ CreateThread(function()
                     if DoesEntityExist(target) and IsPedInAnyVehicle(target, false) and not IsEntityDead(target) and not IsPedAPlayer(target) then
                         local targetVehicle = GetVehiclePedIsIn(target, false)
                         for _, vehicle in ipairs(config.immuneVehicles) do
-                            if GetEntityModel(targetVehicle) == getHash(vehicle) then
+                            if GetEntityModel(targetVehicle) == joaat(vehicle) then
                                 carIsImmune = true
                             end
                         end
@@ -442,7 +438,13 @@ RegisterNetEvent('lockpicks:UseLockpick', function(isAdvanced)
     lockpickDoor(isAdvanced)
 end)
 
--- Backwards Compatibility ONLY -- Remove at some point --
+AddEventHandler('onResourceStart', function(resourceName)
+    if resourceName == GetCurrentResourceName() then
+        TriggerServerEvent('qbx-vehiclekeys:server:setPlayerKeys')
+    end
+end)
+
+-- #region Backwards Compatibility ONLY -- Remove at some point --
 RegisterNetEvent('qb-vehiclekeys:client:AddKeys', function(plate)
     TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
     if cache.vehicle and plate == qbx.getVehiclePlate(cache.vehicle) then
@@ -453,10 +455,4 @@ end)
 RegisterNetEvent('vehiclekeys:client:SetOwner', function(plate)
     TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
 end)
--- Backwards Compatibility ONLY -- Remove at some point --
-
-AddEventHandler('onResourceStart', function(resourceName)
-    if resourceName == GetCurrentResourceName() then
-        TriggerServerEvent('qbx-vehiclekeys:server:setPlayerKeys')
-    end
-end)
+-- #endregion Backwards Compatibility ONLY -- Remove at some point --

--- a/config/client.lua
+++ b/config/client.lua
@@ -153,6 +153,9 @@ return {
     policeAlertChance = 0.75, -- Chance of alerting the police during the day
     policeNightAlertChance = 0.50, -- Chance of alerting the police at night (times: 01-06)
 
+    vehicleAlarmDuration = 10000,
+    lockpickCooldown = 1000,
+
     -- Job Settings
     sharedKeys = { -- Share keys amongst employees. Employees can lock/unlock any job-listed vehicle
         ['police'] = { -- Job name

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,27 +1,11 @@
---[[ FX Information ]]--
 fx_version 'cerulean'
-use_experimental_fxv2_oal 'yes'
-lua54 'yes'
 game 'gta5'
 
---[[ Resource Information ]]--
-version '1.0.0'
-license 'GPL-3.0-or-later'
 description 'vehicle key management system'
 repository 'https://github.com/Qbox-project/qbx_vehiclekeys'
-
---[[ Manifest ]]--
-dependencies {
-    'ox_lib',
-    'qbx_core'
-}
+version '1.0.0'
 
 ox_lib 'locale'
-
-files {
-	'locales/*.json',
-	'config/client.lua'
-}
 
 shared_scripts {
 	'@ox_lib/init.lua',
@@ -35,3 +19,16 @@ client_scripts {
 }
 
 server_script 'server/*.lua'
+
+files {
+	'locales/*.json',
+	'config/client.lua'
+}
+
+dependencies {
+    'ox_lib',
+    'qbx_core'
+}
+
+use_experimental_fxv2_oal 'yes'
+lua54 'yes'

--- a/locales/en.json
+++ b/locales/en.json
@@ -22,7 +22,8 @@
   },
   "notify": {
     "carjack_failed": "Carjacking failed!",
-    "failed_lockedpick": "You fail to find the keys and get frustrated.",
+    "failed_lockedpick": "You failed to lockpick.",
+    "failed_keys": "You fail to find the keys and get frustrated.",
     "fpid": "Fill out the player ID and Plate arguments",
     "gave_keys": "You hand over the keys.",
     "keys_taken": "You get keys to the vehicle!",

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -10,8 +10,7 @@ lib.addCommand('givekeys', {
     },
     restricted = false,
 }, function (source, args)
-    local src = source
-    TriggerClientEvent('qb-vehiclekeys:client:GiveKeys', src, args.id)
+    TriggerClientEvent('qb-vehiclekeys:client:GiveKeys', source, args.id)
 end)
 
 lib.addCommand('addkeys', {
@@ -32,11 +31,10 @@ lib.addCommand('addkeys', {
     },
     restricted = 'group.admin',
 }, function (source, args)
-    local src = source
     if not args.id or not args.plate then
-        exports.qbx_core:Notify(src, locale("notify.fpid"))
-        return
+        return exports.qbx_core:Notify(source, locale("notify.fpid"))
     end
+
     GiveKeys(args.id, args.plate)
 end)
 
@@ -58,10 +56,9 @@ lib.addCommand('removekeys', {
     },
     restricted = 'group.admin',
 }, function (source, args)
-    local src = source
     if not args.id or not args.plate then
-        exports.qbx_core:Notify(src, locale("notify.fpid"))
-        return
+        return exports.qbx_core:Notify(source, locale("notify.fpid"))
     end
+
     RemoveKeys(args.id, args.plate)
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -59,21 +59,6 @@ end)
 ----   Functions   ----
 -----------------------
 
--- local function isVehicleVisibleByServer(plate)
---     local vehicles = GetAllVehicles()
---     if type(vehicles) == "table" then
---         for _, vehicle in ipairs(vehicles) do
---             local p = GetVehicleNumberPlateText(vehicle)
---             if p == plate then
---                 Wait(500)
---                 if GetEntityPopulationType(vehicle) == 7 then
---                     return true
---                 end
---             end
---         end
---     end
--- end
-
 function GiveKeys(source, plate)
     local keys = Player(source).state.keysList or {}
 
@@ -84,13 +69,11 @@ function GiveKeys(source, plate)
 
     if not citizenid then return end
 
-    -- if isVehicleVisibleByServer(plate) then
     if not keysList[citizenid] then
         keysList[citizenid] = {}
     end
 
     keysList[citizenid][plate] = true
-    -- end
 
     exports.qbx_core:Notify(source, locale('notify.keys_taken'))
 end

--- a/shared/functions.lua
+++ b/shared/functions.lua
@@ -1,13 +1,5 @@
 local public = {}
 
---- Gets model hash
---- @param model string | number model name or number.
---- @return number hash of the model.
-function public.getHash(model)
-    if type(model) == 'string' then return joaat(model) end
-    return model
-end
-
 --- Checks if the given two coordinates are close to each other based on distance.
 --- @param coord1 vector3[] The first set of coordinates.
 --- @param coord2 vector3[] The second set of coordinates.


### PR DESCRIPTION
**Major changes**
Change the data structure of vehicleKeys[plate][citizenid] to keysList[citizenid][plate]. This simplifies the logic of most functions.
Instead of synchronizing the variable on the client side, the player's statebag is modified.
Vehicle spawning works in shops, fixed GetKeys function

**Other changes**
fixed lint tests by rewriting imports
lockpicking for all vehicle doors
restored oryginal qbx fxmanifest.lua style

Need to think about how you can optimize the storage of keys in a variable on the server

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
