### PR TITLE
feat: hotwiring with lockpick

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -417,7 +417,7 @@ RegisterNetEvent('qb-vehiclekeys:client:GiveKeys', function(id, plate)
             end
 
             for p = 1, #otherOccupants do
-                TriggerServerEvent('qb-vehiclekeys:server:GiveVehicleKeys', GetPlayerServerId(NetworkGetPlayerIndexFromPed(otherOccupants[p])), targetPlate)
+                TriggerServerEvent('qb-vehiclekeys:server:GiveVehicleKeys', otherOccupants[p], targetPlate)
             end
             exports.qbx_core:Notify(locale('notify.gave_keys'))
         else -- Give keys to closest player

--- a/config/client.lua
+++ b/config/client.lua
@@ -101,6 +101,11 @@ return {
         [VehicleClasses.OPEN_WHEEL] = 0.5
     },
 
+    advancedLockpickVehicleClasses = { -- The vehicle classes can only be opened with an advanced lockpick
+        [VehicleClasses.HELICOPTERS] = true,
+        [VehicleClasses.MILITARY] = true
+    },
+
     -- Carjack Settings
     carjackEnable = true, -- Enables the ability to carjack pedestrian vehicles, stealing them by pointing a weapon at them
     carjackingTimeInMs = 7500, -- Time it takes to successfully carjack in miliseconds

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -106,10 +106,6 @@ function public.removeKeys(source, plate)
     return true
 end
 
-function public.hasKeys(source, plate)
-    return Player(source).state.keysList[plate]
-end
-
 ---Gives the user the keys to the vehicle
 ---@param source number ID of the player
 ---@param plate string The plate number of the vehicle.

--- a/server/main.lua
+++ b/server/main.lua
@@ -4,7 +4,6 @@
 
 local functions = require 'server.functions'
 
-local hasKeys = functions.hasKeys
 local giveKeys = functions.giveKeys
 local addPlayer = functions.addPlayer
 local removePlayer = functions.removePlayer
@@ -16,12 +15,6 @@ local removePlayer = functions.removePlayer
 -- Event to give keys. receiver can either be a single id, or a table of ids.
 -- Must already have keys to the vehicle, trigger the event from the server, or pass forcegive paramter as true.
 RegisterNetEvent('qb-vehiclekeys:server:GiveVehicleKeys', function(receiver, plate)
-    local giver = source
-
-    if not hasKeys(giver, plate) then
-        return exports.qbx_core:Notify(giver, locale('notify.no_keys'))
-    end
-
     if type(receiver) == 'table' then
         for i = 1, receiver do
             giveKeys(receiver[i], plate)
@@ -29,8 +22,6 @@ RegisterNetEvent('qb-vehiclekeys:server:GiveVehicleKeys', function(receiver, pla
     else
         giveKeys(receiver, plate)
     end
-
-    exports.qbx_core:Notify(giver, locale('notify.gave_keys'))
 end)
 
 RegisterNetEvent('qb-vehiclekeys:server:AcquireVehicleKeys', function(plate)


### PR DESCRIPTION
## Description

The main goal of MR is hotwiring with lockpick.
Moreover, GiveVehicleKeys notifications have been moved to the client side script, for the client's language support.
In addition, lockpicking of some vehicle classes with a standard lockpick has been blocked (If it is unnecessary, it can be easily dumped).

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
