### PR TITLE
feat(server): init locks statuses

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -1,7 +1,7 @@
 local config = require 'config.client'
 local functions = require 'shared.functions'
 local getIsCloseToCoords = functions.getIsCloseToCoords
-local getIsVehicleBlacklisted = functions.getIsVehicleBlacklisted
+local getIsVehicleAlwaysUnlocked = functions.getIsVehicleAlwaysUnlocked
 local getIsVehicleImmune = functions.getIsVehicleImmune
 
 local alertSend = false
@@ -32,12 +32,12 @@ end
 ---Checking vehicle on the blacklist.
 ---@param vehicle number The entity number of the vehicle.
 ---@return boolean? `true` if the vehicle is blacklisted, `nil` otherwise.
-function public.getIsVehicleBlacklisted(vehicle)
+function public.getIsVehicleAlwaysUnlocked(vehicle)
     if Entity(vehicle).state.ignoreLocks or GetVehicleClass(vehicle) == 13 then
         return true
     end
 
-    return getIsVehicleBlacklisted(vehicle)
+    return getIsVehicleAlwaysUnlocked(vehicle)
 end
 
 function public.attemptPoliceAlert(type)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -2,12 +2,12 @@ local config = require 'config.client'
 local functions = require 'shared.functions'
 local getIsCloseToCoords = functions.getIsCloseToCoords
 local getIsVehicleAlwaysUnlocked = functions.getIsVehicleAlwaysUnlocked
-local getIsVehicleImmune = functions.getIsVehicleImmune
+local getIsVehicleCarjackingImmune = functions.getIsVehicleCarjackingImmune
 
 local alertSend = false
 local public = {}
 
-public.getIsVehicleImmune = getIsVehicleImmune -- to prevent circular-dependency error
+public.getIsVehicleCarjackingImmune = getIsVehicleCarjackingImmune -- to prevent circular-dependency error
 
 ---Checks if player has vehicle keys
 ---@param plate string The plate number of the vehicle.

--- a/client/main.lua
+++ b/client/main.lua
@@ -10,7 +10,7 @@ local hotwire = functions.hotwire
 local lockpickDoor = functions.lockpickDoor
 local attemptPoliceAlert = functions.attemptPoliceAlert
 local isBlacklistedWeapon = functions.isBlacklistedWeapon
-local getIsVehicleBlacklisted = functions.getIsVehicleBlacklisted
+local getIsVehicleAlwaysUnlocked = functions.getIsVehicleAlwaysUnlocked
 local getVehicleByPlate = functions.getVehicleByPlate
 local areKeysJobShared = functions.areKeysJobShared
 local getIsVehicleImmune = functions.getIsVehicleImmune
@@ -73,7 +73,7 @@ end
 ---@param anim any Aniation
 local function setVehicleDoorLock(vehicle, state, anim)
     if not vehicle then return end
-    if not getIsVehicleBlacklisted(vehicle) then
+    if not getIsVehicleAlwaysUnlocked(vehicle) then
         if hasKeys(qbx.getVehiclePlate(vehicle)) or areKeysJobShared(vehicle) then
 
             if anim then
@@ -181,7 +181,7 @@ local function showHotwiringLabel()
             local plate = qbx.getVehiclePlate(cache.vehicle)
             if cache.seat == -1
                 and not hasKeys(plate)
-                and not getIsVehicleBlacklisted(cache.vehicle)
+                and not getIsVehicleAlwaysUnlocked(cache.vehicle)
                 and not areKeysJobShared(cache.vehicle)
             then
                 local vehiclePos = GetOffsetFromEntityInWorldCoords(cache.vehicle, 0.0, 1.0, 0.5)
@@ -364,7 +364,7 @@ engineBind = lib.addKeybind({
 
 RegisterNetEvent('QBCore:Client:VehicleInfo', function(data)
     if not LocalPlayer.state.isLoggedIn and data.event ~= 'Entering' then return end
-    if getIsVehicleBlacklisted(data.vehicle) then return end
+    if getIsVehicleAlwaysUnlocked(data.vehicle) then return end
     local isVehicleImmune = getIsVehicleImmune(data.vehicle)
     local driver = GetPedInVehicleSeat(data.vehicle, -1)
     local plate = qbx.getVehiclePlate(data.vehicle)

--- a/client/main.lua
+++ b/client/main.lua
@@ -266,6 +266,7 @@ local function carjackVehicle(target)
                     end)
                 end
                 TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
+                TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(vehicle), 1)
                 TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
             else
                 exports.qbx_core:Notify(locale('notify.carjack_failed'), 'error')
@@ -388,29 +389,7 @@ RegisterNetEvent('QBCore:Client:VehicleInfo', function(data)
                 end
                 isTakingKeys = false
             end
-        elseif config.lockNPCDrivenCars then
-            TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', data.netId, 2)
-        else
-            TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', data.netId, 1)
-            TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
-
-            --Make passengers flee
-            local pedsInVehicle = getPedsInVehicle(data.vehicle)
-            for i = 1, #pedsInVehicle do
-                local pedInVehicle = pedsInVehicle[i]
-                if pedInVehicle ~= GetPedInVehicleSeat(data.vehicle, -1) then
-                    makePedFlee(pedInVehicle)
-                end
-            end
         end
-        -- Parked car logic
-    elseif driver == 0 and
-        not (isTakingKeys
-        or Entity(data.vehicle).state.isOpen
-        or Entity(data.vehicle).state.vehicleid
-        or hasKeys(plate))
-    then
-        TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', data.netId, config.lockNPCParkedCars and 2 or 1)
     end
 end)
 
@@ -461,7 +440,7 @@ if config.carjackEnable then
     end)
 end
 
-AddEventHandler('onResourceStart', function (resourceName)
+AddEventHandler('onResourceStart', function(resourceName)
     if (GetCurrentResourceName() ~= resourceName) then return end
 
     showHotwiringLabel()

--- a/client/main.lua
+++ b/client/main.lua
@@ -13,7 +13,7 @@ local isBlacklistedWeapon = functions.isBlacklistedWeapon
 local getIsVehicleAlwaysUnlocked = functions.getIsVehicleAlwaysUnlocked
 local getVehicleByPlate = functions.getVehicleByPlate
 local areKeysJobShared = functions.areKeysJobShared
-local getIsVehicleImmune = functions.getIsVehicleImmune
+local getIsVehicleCarjackingImmune = functions.getIsVehicleCarjackingImmune
 
 -----------------------
 ----   Variables   ----
@@ -313,7 +313,7 @@ local function watchCarjackingAttempts()
                     and not IsPedAPlayer(target)
                 then
                     local targetveh = GetVehiclePedIsIn(target, false)
-                    local isVehicleImmune = getIsVehicleImmune(targetveh)
+                    local isVehicleImmune = getIsVehicleCarjackingImmune(targetveh)
 
                     if not isVehicleImmune
                         and GetPedInVehicleSeat(targetveh, -1) == target
@@ -365,7 +365,7 @@ engineBind = lib.addKeybind({
 RegisterNetEvent('QBCore:Client:VehicleInfo', function(data)
     if not LocalPlayer.state.isLoggedIn and data.event ~= 'Entering' then return end
     if getIsVehicleAlwaysUnlocked(data.vehicle) then return end
-    local isVehicleImmune = getIsVehicleImmune(data.vehicle)
+    local isVehicleImmune = getIsVehicleCarjackingImmune(data.vehicle)
     local driver = GetPedInVehicleSeat(data.vehicle, -1)
     local plate = qbx.getVehiclePlate(data.vehicle)
 

--- a/config/client.lua
+++ b/config/client.lua
@@ -45,10 +45,6 @@ return {
 
     vehicleMaximumLockingDistance = 5.0, -- Minimum distance for vehicle locking
 
-    -- NPC Vehicle Lock States
-    lockNPCDrivenCars = true, -- Lock state for NPC cars being driven by NPCs [true = locked, false = unlocked]
-    lockNPCParkedCars = true, -- Lock state for NPC parked cars [true = locked, false = unlocked]
-
     -- Lockpick Settings
     removeNormalLockpickChance = { -- Chance to remove lockpick on fail by vehicle class
         [VehicleClasses.COMPACTS] = 0.5,

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,3 +1,7 @@
 return {
     runClearCronMinutes = 5,
+
+    -- NPC Vehicle Lock States
+    lockNPCDrivenCars = true, -- Lock state for NPC cars being driven by NPCs [true = locked, false = unlocked]
+    lockNPCParkedCars = true, -- Lock state for NPC parked cars [true = locked, false = unlocked]
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -9,7 +9,7 @@ local sharedFunctions = require 'shared.functions'
 local giveKeys = functions.giveKeys
 local addPlayer = functions.addPlayer
 local removePlayer = functions.removePlayer
-local getIsVehicleBlacklisted = sharedFunctions.getIsVehicleBlacklisted
+local getIsVehicleAlwaysUnlocked = sharedFunctions.getIsVehicleAlwaysUnlocked
 
 -----------------------
 ----    Events     ----
@@ -59,6 +59,6 @@ AddEventHandler('entityCreated', function (vehicle)
     if not vehicle or GetEntityType(vehicle) ~= 2 or GetEntityPopulationType(vehicle) > 5 then return end
     local isDriver = GetPedInVehicleSeat(vehicle, -1) ~= 0
     local isLocked = (config.lockNPCDrivenCars and isDriver) or (config.lockNPCParkedCars and not isDriver)
-                        and GetVehicleType(vehicle) ~= 'bike' and not getIsVehicleBlacklisted(vehicle)
+                        and GetVehicleType(vehicle) ~= 'bike' and not getIsVehicleAlwaysUnlocked(vehicle)
     SetVehicleDoorsLocked(vehicle, isLocked and 2 or 1)
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -53,14 +53,12 @@ AddEventHandler('playerDropped', function()
     removePlayer(source --[[@as integer]])
 end)
 
-if config.lockNPCDrivenCars or config.lockNPCParkedCars then
-    ---Lock every spawned vehicle
-    ---@param vehicle number The entity number of the vehicle.
-    AddEventHandler('entityCreated', function (vehicle)
-        if not vehicle or GetEntityType(vehicle) ~= 2 or GetEntityPopulationType(vehicle) > 5 then return end
-        local isDriver = GetPedInVehicleSeat(vehicle, -1) ~= 0
-        local isLocked = (config.lockNPCDrivenCars and isDriver) or (config.lockNPCParkedCars and not isDriver)
-                            and GetVehicleType(vehicle) ~= 'bike' and not getIsVehicleBlacklisted(vehicle)
-        SetVehicleDoorsLocked(vehicle, isLocked and 2 or 1)
-    end)
-end
+---Lock every spawned vehicle
+---@param vehicle number The entity number of the vehicle.
+AddEventHandler('entityCreated', function (vehicle)
+    if not vehicle or GetEntityType(vehicle) ~= 2 or GetEntityPopulationType(vehicle) > 5 then return end
+    local isDriver = GetPedInVehicleSeat(vehicle, -1) ~= 0
+    local isLocked = (config.lockNPCDrivenCars and isDriver) or (config.lockNPCParkedCars and not isDriver)
+                        and GetVehicleType(vehicle) ~= 'bike' and not getIsVehicleBlacklisted(vehicle)
+    SetVehicleDoorsLocked(vehicle, isLocked and 2 or 1)
+end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,11 +2,14 @@
 ----    Imports    ----
 -----------------------
 
+local config = require 'config.server'
 local functions = require 'server.functions'
+local sharedFunctions = require 'shared.functions'
 
 local giveKeys = functions.giveKeys
 local addPlayer = functions.addPlayer
 local removePlayer = functions.removePlayer
+local getIsVehicleBlacklisted = sharedFunctions.getIsVehicleBlacklisted
 
 -----------------------
 ----    Events     ----
@@ -49,3 +52,15 @@ end)
 AddEventHandler('playerDropped', function()
     removePlayer(source --[[@as integer]])
 end)
+
+if config.lockNPCDrivenCars or config.lockNPCParkedCars then
+    ---Lock every spawned vehicle
+    ---@param vehicle number The entity number of the vehicle.
+    AddEventHandler('entityCreated', function (vehicle)
+        if not vehicle or GetEntityType(vehicle) ~= 2 then return end
+        local isDriver = GetPedInVehicleSeat(vehicle, -1) ~= 0
+        local isLocked = (config.lockNPCDrivenCars and isDriver) or (config.lockNPCParkedCars and not isDriver)
+                            and GetVehicleType(vehicle) ~= 'bike' and not getIsVehicleBlacklisted(vehicle)
+        SetVehicleDoorsLocked(vehicle, isLocked and 2 or 1)
+    end)
+end

--- a/server/main.lua
+++ b/server/main.lua
@@ -56,7 +56,10 @@ end)
 ---Lock every spawned vehicle
 ---@param vehicle number The entity number of the vehicle.
 AddEventHandler('entityCreated', function (vehicle)
-    if not vehicle or GetEntityType(vehicle) ~= 2 or GetEntityPopulationType(vehicle) > 5 then return end
+    if not vehicle
+        or GetEntityType(vehicle) ~= 2
+        or GetEntityPopulationType(vehicle) > 5
+    then return end
     local isDriver = GetPedInVehicleSeat(vehicle, -1) ~= 0
     local isLocked = (config.lockNPCDrivenCars and isDriver) or (config.lockNPCParkedCars and not isDriver)
                         and GetVehicleType(vehicle) ~= 'bike' and not getIsVehicleAlwaysUnlocked(vehicle)

--- a/server/main.lua
+++ b/server/main.lua
@@ -57,7 +57,7 @@ if config.lockNPCDrivenCars or config.lockNPCParkedCars then
     ---Lock every spawned vehicle
     ---@param vehicle number The entity number of the vehicle.
     AddEventHandler('entityCreated', function (vehicle)
-        if not vehicle or GetEntityType(vehicle) ~= 2 then return end
+        if not vehicle or GetEntityType(vehicle) ~= 2 or GetEntityPopulationType(vehicle) > 5 then return end
         local isDriver = GetPedInVehicleSeat(vehicle, -1) ~= 0
         local isLocked = (config.lockNPCDrivenCars and isDriver) or (config.lockNPCParkedCars and not isDriver)
                             and GetVehicleType(vehicle) ~= 'bike' and not getIsVehicleBlacklisted(vehicle)

--- a/shared/functions.lua
+++ b/shared/functions.lua
@@ -29,7 +29,7 @@ end
 ---Checking vehicle on the immunes list.
 ---@param vehicle any
 ---@return boolean? `true` if the vehicle is immune, `nil` otherwise.
-function public.getIsVehicleImmune(vehicle)
+function public.getIsVehicleCarjackingImmune(vehicle)
     return getIsVehicleOnList(vehicle, config.immuneVehicles)
 end
 

--- a/shared/functions.lua
+++ b/shared/functions.lua
@@ -22,7 +22,7 @@ end
 ---Checking vehicle on the blacklist.
 ---@param vehicle number The entity number of the vehicle.
 ---@return boolean? `true` if the vehicle is blacklisted, `nil` otherwise.
-function public.getIsVehicleBlacklisted(vehicle)
+function public.getIsVehicleAlwaysUnlocked(vehicle)
     return getIsVehicleOnList(vehicle, config.noLockVehicles)
 end
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Each newly created vehicle has its initial lock status set. This is a one-time action for each vehicle.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
