### PR TITLE
feat(qb-vehiclekeys:client:GiveKeys): remove redundant has keys checking

### DIFF
--- a/client/commands.lua
+++ b/client/commands.lua
@@ -29,9 +29,6 @@ end
 local function giveKeys(id, plate)
     local distance = #(GetEntityCoords(cache.ped) - GetEntityCoords(GetPlayerPed(GetPlayerFromServerId(id))))
     if distance < 3 then
-        if not hasKeys(plate) then
-            return exports.qbx_core:Notify(locale('notify.no_keys'))
-        end
         TriggerServerEvent('qb-vehiclekeys:server:GiveVehicleKeys', id, plate)
         exports.qbx_core:Notify(locale('notify.gave_keys'))
     else
@@ -51,10 +48,6 @@ RegisterNetEvent('qb-vehiclekeys:client:GiveKeys', function(id, plate)
         giveKeys(id, plate)
     elseif IsPedSittingInVehicle(cache.ped, vehicle) then -- Give keys to everyone in vehicle
         local otherOccupants = getOtherPlayersInVehicle(vehicle)
-        if not hasKeys(qbx.getVehiclePlate(vehicle)) then
-            return exports.qbx_core:Notify(locale('notify.no_keys'))
-        end
-
         for p = 1, #otherOccupants do
             TriggerServerEvent('qb-vehiclekeys:server:GiveVehicleKeys', otherOccupants[p], plate)
         end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Checking whether a player has keys is checked in too many parts of the code.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
