### PR TITLE
fix(client/main): default auto lock to false if job not in config

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -377,14 +377,14 @@ for _, info in pairs(config.sharedKeys) do
             local leftVehicle = cache.vehicle
             if not vehicle and leftVehicle then
                 local isShared = areKeysJobShared(leftVehicle)
-                local isAutolockEnabled = config.sharedKeys[QBX.PlayerData.job.name].enableAutolock
+                local isAutolockEnabled = config.sharedKeys[QBX.PlayerData.job.name]?.enableAutolock
 
                 if isShared and isAutolockEnabled then
                     TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(leftVehicle), 2)
                 end
             end
         end)
-        break;
+        break
     end
 end
 


### PR DESCRIPTION
Previously, this was causing a nil exception