### PR TITLE
refactor: default locked state

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -2,10 +2,8 @@ local config = require 'config.client'
 local functions = require 'shared.functions'
 local getIsCloseToCoords = functions.getIsCloseToCoords
 local getIsBlacklistedWeapon = functions.getIsBlacklistedWeapon
-local getIsVehicleAlwaysUnlocked = functions.getIsVehicleAlwaysUnlocked
 local getIsVehicleLockpickImmune = functions.getIsVehicleLockpickImmune
 local getIsVehicleCarjackingImmune = functions.getIsVehicleCarjackingImmune
-local getIsVehicleTypeAlwaysUnlocked = functions.getIsVehicleTypeAlwaysUnlocked
 local getIsVehicleTypeShared = functions.getIsVehicleTypeShared
 local getIsVehicleShared = functions.getIsVehicleShared
 
@@ -63,15 +61,6 @@ function public.toggleEngine(vehicle)
 end
 
 exports('ToggleEngine', public.toggleEngine)
-
----Checking vehicle on the blacklist.
----@param vehicle number The entity number of the vehicle.
----@return boolean? `true` if the vehicle is blacklisted, `nil` otherwise.
-function public.getIsVehicleAlwaysUnlocked(vehicle)
-    return Entity(vehicle).state.ignoreLocks
-        or getIsVehicleAlwaysUnlocked(vehicle)
-        or getIsVehicleTypeAlwaysUnlocked(vehicle)
-end
 
 function public.getNPCPedsInVehicle(vehicle)
     local otherPeds = {}

--- a/client/main.lua
+++ b/client/main.lua
@@ -4,6 +4,7 @@
 
 local config = require 'config.client'
 local functions = require 'client.functions'
+local sharedFunctions = require 'shared.functions'
 
 local hotwire = functions.hotwire
 local toggleEngine = functions.toggleEngine
@@ -16,7 +17,7 @@ local getNPCPedsInVehicle = functions.getNPCPedsInVehicle
 local sendPoliceAlertAttempt = functions.sendPoliceAlertAttempt
 local getIsVehicleAccessible = functions.getIsVehicleAccessible
 local getIsBlacklistedWeapon = functions.getIsBlacklistedWeapon
-local getIsVehicleAlwaysUnlocked = functions.getIsVehicleAlwaysUnlocked
+local getIsVehicleAlwaysUnlocked = sharedFunctions.getIsVehicleAlwaysUnlocked
 local getIsVehicleCarjackingImmune = functions.getIsVehicleCarjackingImmune
 
 -----------------------

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -7,9 +7,28 @@ return {
         'bike'
     },
 
-    -- Vehicles that will never lock example:
+    -- Vehicles that will never lock
+     ---@type VehicleSelection
     noLockVehicles = {
-        -- `stockade` -- example
+        models = {
+            -- `stockade` -- example
+        },
+
+        types = {
+
+        }
+    },
+
+    --- vehicles which spawn locked
+    ---@type VehicleSelection
+    lockedVehicles = {
+        models = {
+            -- `stockade` -- example
+        },
+
+        types = {
+
+        }
     },
 
     -- Vehicles that cannot be jacked
@@ -18,10 +37,6 @@ return {
     },
 
     lockpickImmuneVehicles = {
-        -- `stockade` -- example
-    },
-
-    lockedVehicles = {
         -- `stockade` -- example
     },
 
@@ -57,8 +72,4 @@ return {
         `WEAPON_SMOKEGRENADE`,
         -- Add more weapon names as needed
     },
-
-    noLockVehicleTypes = {
-        -- 'boat' -- example
-    }
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,10 +5,8 @@ local sharedFunctions = require 'shared.functions'
 local giveKeys = functions.giveKeys
 local addPlayer = functions.addPlayer
 local removePlayer = functions.removePlayer
-local getIsVehicleLockpickImmune = sharedFunctions.getIsVehicleLockpickImmune
 local getIsVehicleAlwaysUnlocked = sharedFunctions.getIsVehicleAlwaysUnlocked
 local getIsVehicleInitiallyLocked = sharedFunctions.getIsVehicleInitiallyLocked
-local getIsVehicleTypeAlwaysUnlocked = sharedFunctions.getIsVehicleTypeAlwaysUnlocked
 
 ---@enum EntityType
 local EntityType = {
@@ -74,10 +72,9 @@ AddEventHandler('entityCreated', function (entity)
     local vehicle = type == EntityType.Ped and GetVehiclePedIsIn(entity, false) or entity
 
     local chance = math.random()
-    local isLocked = getIsVehicleLockpickImmune(vehicle)
-        or (getIsVehicleInitiallyLocked(vehicle)
+    local isLocked = (getIsVehicleInitiallyLocked(vehicle)
             or (type == EntityType.Ped and chance < config.lockNPCDrivenCarsChance)
             or (type == EntityType.Vehicle and chance < config.lockNPCParkedCarsChance))
-        and not(getIsVehicleTypeAlwaysUnlocked(vehicle) or getIsVehicleAlwaysUnlocked(vehicle))
+        and not getIsVehicleAlwaysUnlocked(vehicle)
     SetVehicleDoorsLocked(vehicle, isLocked and 2 or 1)
 end)

--- a/shared/functions.lua
+++ b/shared/functions.lua
@@ -29,7 +29,17 @@ end
 ---@param vehicle number The entity number of the vehicle.
 ---@return boolean? `true` if the vehicle is blacklisted, `nil` otherwise.
 function public.getIsVehicleAlwaysUnlocked(vehicle)
-    return getIsOnList(GetEntityModel(vehicle), config.noLockVehicles)
+    return getIsOnList(GetEntityModel(vehicle), config.noLockVehicles.models)
+        or getIsOnList(GetVehicleType(vehicle), config.noLockVehicles.types)
+        or Entity(vehicle).state.ignoreLocks
+end
+
+---Checks the vehicle is always locked at spawn.
+---@param vehicle number The entity number of the vehicle.
+---@return boolean? `true` if the vehicle is locked, `nil` otherwise.
+function public.getIsVehicleInitiallyLocked(vehicle)
+    return getIsOnList(GetEntityModel(vehicle), config.lockedVehicles.models)
+        or getIsOnList(GetVehicleType(vehicle), config.lockedVehicles.types)
 end
 
 ---Checks the vehicle is carjacking immune.
@@ -46,13 +56,6 @@ function public.getIsVehicleLockpickImmune(vehicle)
     return getIsOnList(GetEntityModel(vehicle), config.lockpickImmuneVehicles)
 end
 
----Checks the vehicle is always locked at spawn.
----@param vehicle number The entity number of the vehicle.
----@return boolean? `true` if the vehicle is locked, `nil` otherwise.
-function public.getIsVehicleInitiallyLocked(vehicle)
-    return getIsOnList(GetEntityModel(vehicle), config.lockedVehicles)
-end
-
 ---Checks if the weapon cannot be used to steal keys from drivers.
 ---@param weaponHash number The current weapon hash.
 ---@return boolean? `true` if the weapon cannot be used to carjacking, `nil` otherwise.
@@ -65,13 +68,6 @@ end
 ---@return boolean? `true` if the vehicle type is accessible, `nil` otherwise.
 function public.getIsVehicleTypeShared(vehicle)
     return getIsOnList(GetVehicleType(vehicle), config.sharedVehicleTypes)
-end
-
----Checks if the vehicle type cannot be locked.
----@param vehicle number The entity number of the vehicle.
----@return boolean? `true` if the vehicle type is blacklisted, `nil` otherwise.
-function public.getIsVehicleTypeAlwaysUnlocked(vehicle)
-    return getIsOnList(GetVehicleType(vehicle), config.noLockVehicleTypes)
 end
 
 return public

--- a/types.lua
+++ b/types.lua
@@ -1,0 +1,7 @@
+---@meta
+
+---@alias VehicleType 'automobile' | 'bike' | 'boat' | 'heli' | 'plane' | 'submarine' | 'trailer' | 'train'
+
+---@class VehicleSelection
+---@field types VehicleType[]
+---@field models number[]


### PR DESCRIPTION
- Combined getIsVehicleAlwaysUnlocked & getIsVehicleTypeAlwaysUnlocked into one function, which also checks the state bag for ignoreLocks.
- Combined config for noLockVehicles and noLockVehicleTypes as sub-fields to make them visually closer together and linked.
- Added types field to lockedVehicles in config as a feature
- No longer using getIsVehicleLockpickImmune to mean that the vehicle should spawn locked. This behavior seemed like a side-effect, as one wouldn't assume that a vehicle that couldn't be lock picked was locked.
- Created types.lua meta file for containing typed annotations