### PR TITLE
refactor: vehicles config

### DIFF
--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,4 +1,24 @@
 return {
+    ---For a given vehicle, the config used is based on precendence of:
+    ---1. model
+    ---2. type
+    ---3. default
+    ---Each field inherits from its parent if not specified.
+    ---@type VehiclesConfig
+    vehicles = {
+        default = {
+            spawnLocked = 1.0,
+        },
+        types = {
+
+        },
+        models = {
+            -- Example:
+            -- [`stockade`] = {
+            --     spawnLocked = 0.5
+            -- }
+        }
+    },
     sharedVehicles = {
         -- `stockade` -- example
     },
@@ -10,18 +30,6 @@ return {
     -- Vehicles that will never lock
      ---@type VehicleSelection
     noLockVehicles = {
-        models = {
-            -- `stockade` -- example
-        },
-
-        types = {
-
-        }
-    },
-
-    --- vehicles which spawn locked
-    ---@type VehicleSelection
-    lockedVehicles = {
         models = {
             -- `stockade` -- example
         },

--- a/shared/functions.lua
+++ b/shared/functions.lua
@@ -36,10 +36,14 @@ end
 
 ---Checks the vehicle is always locked at spawn.
 ---@param vehicle number The entity number of the vehicle.
----@return boolean? `true` if the vehicle is locked, `nil` otherwise.
+---@return boolean `true` if the vehicle is locked, `false` otherwise.
 function public.getIsVehicleInitiallyLocked(vehicle)
-    return getIsOnList(GetEntityModel(vehicle), config.lockedVehicles.models)
-        or getIsOnList(GetVehicleType(vehicle), config.lockedVehicles.types)
+    local isVehicleSpawnLocked = public.getVehicleConfig(vehicle).spawnLocked
+    if type(isVehicleSpawnLocked) == 'number' then
+        return math.random() < isVehicleSpawnLocked
+    else
+        return isVehicleSpawnLocked ~= nil
+    end
 end
 
 ---Checks the vehicle is carjacking immune.
@@ -68,6 +72,18 @@ end
 ---@return boolean? `true` if the vehicle type is accessible, `nil` otherwise.
 function public.getIsVehicleTypeShared(vehicle)
     return getIsOnList(GetVehicleType(vehicle), config.sharedVehicleTypes)
+end
+
+---Gets the vehicle's config
+---@param vehicle number
+---@return VehicleConfig
+function public.getVehicleConfig(vehicle)
+    local modelConfig = config.vehicles.models[GetEntityModel(vehicle)]
+    local typeConfig = config.vehicles.types[GetVehicleType(vehicle)]
+    local defaultConfig = config.vehicles.default
+    return {
+        spawnLocked = modelConfig.spawnLocked or typeConfig.spawnLocked or defaultConfig.spawnLocked or 1.0
+    }
 end
 
 return public

--- a/types.lua
+++ b/types.lua
@@ -5,3 +5,11 @@
 ---@class VehicleSelection
 ---@field types VehicleType[]
 ---@field models number[]
+
+---@class VehiclesConfig
+---@field default VehicleConfig
+---@field types table<VehicleType, VehicleConfig>
+---@field models table<number, VehicleConfig>
+
+---@class VehicleConfig
+---@field spawnLocked? boolean | number ratio 0.0 - 1.0


### PR DESCRIPTION
Currently, the config is split up as a bunch of lists of vehicles that apply to each property. This can be confusing and difficult to reason about the properties that apply to each vehicle. Additionally, this structure allows conflicting properties to be applied to the same vehicle such as no lock and spawned locked.

This PR introduces a new config structure, which is an inversion of the current one. Vehicles are now the top level key, and a list of properties and config options pertaining to that vehicle are the value. This makes the config behavior per vehicle. Aside from directly configuring individual models, this structure also allows for configuring vehicle types and specifying a default for all vehicles. This inherits, meaning that for any given property field, the model's property will be used, falling back to the type's property, falling back to the default property value.

Done with the spawnLocked property to start with. Further properties to be added in future PRs.