### PR TITLE
refactor: vehicle config by category and moving things to shared config

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -13,8 +13,7 @@ public.getIsBlacklistedWeapon = getIsBlacklistedWeapon
 public.getIsCloseToCoords = getIsCloseToCoords
 
 function public.getIsVehicleShared(vehicle)
-    return config.sharedVehicleClasses[GetVehicleClass(vehicle)]
-        or getIsVehicleShared(vehicle)
+    return getIsVehicleShared(vehicle)
 end
 
 ---Grants keys for job shared vehicles
@@ -169,15 +168,16 @@ end
 
 ---Chance to destroy lockpick
 ---@param isAdvancedLockedpick any
----@param vehicleClass any
-local function breakLockpick(isAdvancedLockedpick, vehicleClass)
+---@param vehicle number
+local function breakLockpick(isAdvancedLockedpick, vehicle)
     local chance = math.random()
+    local vehicleConfig = functions.getVehicleConfig(vehicle)
     if isAdvancedLockedpick then -- there is no benefit to using an advanced tool in the default configuration.
-        if chance <= config.removeAdvancedLockpickChance[vehicleClass] then
+        if chance <= vehicleConfig.removeAdvancedLockpickChance then
             TriggerServerEvent("qb-vehiclekeys:server:breakLockpick", "advancedlockpick")
         end
     else
-        if chance <= config.removeNormalLockpickChance[vehicleClass] then
+        if chance <= vehicleConfig.removeNormalLockpickChance then
             TriggerServerEvent("qb-vehiclekeys:server:breakLockpick", "lockpick")
         end
     end
@@ -206,7 +206,7 @@ local function lockpickCallback(vehicle, isAdvancedLockedpick, isSuccess)
         exports.qbx_core:Notify(locale('notify.failed_lockedpick'), 'error')
     end
 
-    breakLockpick(isAdvancedLockedpick, GetVehicleClass(vehicle))
+    breakLockpick(isAdvancedLockedpick, vehicle)
 end
 
 local islockpickingProcessLocked = false -- lock flag
@@ -275,7 +275,7 @@ local function hotwireCallback(vehicle, isAdvancedLockedpick, isSuccess)
         exports.qbx_core:Notify(locale('notify.failed_lockedpick'), 'error')
     end
 
-    breakLockpick(isAdvancedLockedpick, GetVehicleClass(vehicle))
+    breakLockpick(isAdvancedLockedpick, vehicle)
 end
 
 local isHotwiringProcessLocked = false -- lock flag

--- a/client/main.lua
+++ b/client/main.lua
@@ -61,7 +61,8 @@ end
 
 exports('SetVehicleDoorLock', setVehicleDoorLock)
 
-local function findKeys(vehicleModel, vehicleClass, plate)
+local function findKeys(vehicleModel, vehicleClass, plate, vehicle)
+    local vehicleConfig = sharedFunctions.getVehicleConfig(vehicle)
     local hotwireTime = math.random(config.minKeysSearchTime, config.maxKeysSearchTime)
 
     local anim = config.anims.lockpick.model[vehicleModel]
@@ -80,7 +81,7 @@ local function findKeys(vehicleModel, vehicleClass, plate)
             combat = true,
         }
     }) then
-        if math.random() <= config.findKeysChance[vehicleClass] then
+        if math.random() <= vehicleConfig.findKeysChance[vehicle] then
             TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
             return true
         else
@@ -310,7 +311,7 @@ lib.addKeybind({
             local plate = qbx.getVehiclePlate(vehicle)
             local isFound
             if not getIsVehicleAccessible(vehicle, plate) then
-                isFound = findKeys(GetEntityModel(vehicle), GetVehicleClass(vehicle), plate)
+                isFound = findKeys(GetEntityModel(vehicle), GetVehicleClass(vehicle), plate, vehicle)
                 SetTimeout(10000, function()
                     sendPoliceAlertAttempt('steal')
                 end)

--- a/config/client.lua
+++ b/config/client.lua
@@ -86,60 +86,6 @@ return {
     -- Lockpick Settings
     keepVehicleRunning = true,
 
-    ---@type table<VehicleClass, number>
-    removeNormalLockpickChance = { -- Chance to remove lockpick on fail by vehicle class
-        [VehicleClass.COMPACTS] = 0.5,
-        [VehicleClass.SEDANS] = 0.5,
-        [VehicleClass.SUVS] = 0.5,
-        [VehicleClass.COUPES] = 0.5,
-        [VehicleClass.MUSCLE] = 0.5,
-        [VehicleClass.SPORTS_CLASSICS] = 0.5,
-        [VehicleClass.SPORTS] = 0.5,
-        [VehicleClass.SUPER] = 0.5,
-        [VehicleClass.MOTORCYCLES] = 0.5,
-        [VehicleClass.OFF_ROAD] = 0.5,
-        [VehicleClass.INDUSTRIAL] = 0.5,
-        [VehicleClass.UTILITY] = 0.5,
-        [VehicleClass.VANS] = 0.5,
-        [VehicleClass.CYCLES] = 0.5,
-        [VehicleClass.BOATS] = 0.5,
-        [VehicleClass.HELICOPTERS] = 0.5,
-        [VehicleClass.PLANES] = 0.5,
-        [VehicleClass.SERVICE] = 0.5,
-        [VehicleClass.EMERGENCY] = 0.5,
-        [VehicleClass.MILITARY] = 0.5,
-        [VehicleClass.COMMERCIAL] = 0.5,
-        [VehicleClass.TRAINS] = 0.5,
-        [VehicleClass.OPEN_WHEEL] = 0.5
-    },
-
-    ---@type table<VehicleClass, number>
-    removeAdvancedLockpickChance = { -- Chance to remove advanced lockpick on fail by vehicle class
-        [VehicleClass.COMPACTS] = 0.5,
-        [VehicleClass.SEDANS] = 0.5,
-        [VehicleClass.SUVS] = 0.5,
-        [VehicleClass.COUPES] = 0.5,
-        [VehicleClass.MUSCLE] = 0.5,
-        [VehicleClass.SPORTS_CLASSICS] = 0.5,
-        [VehicleClass.SPORTS] = 0.5,
-        [VehicleClass.SUPER] = 0.5,
-        [VehicleClass.MOTORCYCLES] = 0.5,
-        [VehicleClass.OFF_ROAD] = 0.5,
-        [VehicleClass.INDUSTRIAL] = 0.5,
-        [VehicleClass.UTILITY] = 0.5,
-        [VehicleClass.VANS] = 0.5,
-        [VehicleClass.CYCLES] = 0.5,
-        [VehicleClass.BOATS] = 0.5,
-        [VehicleClass.HELICOPTERS] = 0.5,
-        [VehicleClass.PLANES] = 0.5,
-        [VehicleClass.SERVICE] = 0.5,
-        [VehicleClass.EMERGENCY] = 0.5,
-        [VehicleClass.MILITARY] = 0.5,
-        [VehicleClass.COMMERCIAL] = 0.5,
-        [VehicleClass.TRAINS] = 0.5,
-        [VehicleClass.OPEN_WHEEL] = 0.5
-    },
-
     -- Carjack Settings
     carjackEnable = true,                -- Enables the ability to carjack pedestrian vehicles, stealing them by pointing a weapon at them
     carjackingTimeInMs = 7500,           -- Time it takes to successfully carjack in miliseconds
@@ -159,32 +105,6 @@ return {
     },
 
     -- Hotwire Settings
-    ---@type table<VehicleClass, number>
-    findKeysChance = { -- Chance for a successful hotwire by vehicle Class
-        [VehicleClass.COMPACTS] = 0.5,
-        [VehicleClass.SEDANS] = 0.5,
-        [VehicleClass.SUVS] = 0.5,
-        [VehicleClass.COUPES] = 0.5,
-        [VehicleClass.MUSCLE] = 0.5,
-        [VehicleClass.SPORTS_CLASSICS] = 0.5,
-        [VehicleClass.SPORTS] = 0.5,
-        [VehicleClass.SUPER] = 0.5,
-        [VehicleClass.MOTORCYCLES] = 0.5,
-        [VehicleClass.OFF_ROAD] = 0.5,
-        [VehicleClass.INDUSTRIAL] = 0.5,
-        [VehicleClass.UTILITY] = 0.5,
-        [VehicleClass.VANS] = 0.5,
-        [VehicleClass.CYCLES] = 0.5,
-        [VehicleClass.BOATS] = 0.5,
-        [VehicleClass.HELICOPTERS] = 0.5,
-        [VehicleClass.PLANES] = 0.5,
-        [VehicleClass.SERVICE] = 0.5,
-        [VehicleClass.EMERGENCY] = 0.5,
-        [VehicleClass.MILITARY] = 0.5,
-        [VehicleClass.COMMERCIAL] = 0.5,
-        [VehicleClass.TRAINS] = 0.5,
-        [VehicleClass.OPEN_WHEEL] = 0.5
-    },
     timeBetweenHotwires = 5000, -- Time in milliseconds between hotwire attempts
     minKeysSearchTime = 20000,  -- Minimum hotwire time in milliseconds
     maxKeysSearchTime = 40000,  -- Maximum hotwire time in milliseconds
@@ -216,11 +136,6 @@ return {
                 [`towtruck`] = true,
             }
         }
-    },
-
-    ---@type table<VehicleClass, boolean>
-    sharedVehicleClasses = {
-        [VehicleClass.CYCLES] = true
     },
 
     ---@class SkillCheckConfigEntry

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,22 +1,32 @@
 return {
     ---For a given vehicle, the config used is based on precendence of:
     ---1. model
-    ---2. type
-    ---3. default
+    ---2. category from qbx_core shared/vehicles.lua
+    ---3. type
+    ---4. default
     ---Each field falls back to its parent value if not specified.
     ---Example: model's shared value is nil, so the type's shared value is used.
-    ---@type VehiclesConfig
     vehicles = {
+        ---@type VehicleConfig
         default = {
             noLock = false,
             spawnLocked = 1.0,
             carjackingImmune = false,
             lockpickImmune = false,
             shared = false,
+            removeNormalLockpickChance = 1.0,
+            removeAdvancedLockpickChance = 1.0,
+            findKeysChance = 0.5,
         },
+        ---@type table<string, VehicleConfig>
+        categories = {
+
+        },
+        ---@type table<VehicleType, VehicleConfig>
         types = {
 
         },
+        ---@type table<Hash, VehicleConfig>
         models = {
             -- Example:
             -- [`stockade`] = {

--- a/shared/functions.lua
+++ b/shared/functions.lua
@@ -67,13 +67,13 @@ function public.getIsBlacklistedWeapon(weaponHash)
 end
 
 local function findConfigValue(filteredConfig, key, default)
-    if filteredConfig.modelConfig[key] ~= nil then
+    if filteredConfig.modelConfig?[key] ~= nil then
         return filteredConfig.modelConfig[key]
-    elseif filteredConfig.categoryConfig[key] ~= nil then
+    elseif filteredConfig.categoryConfig?[key] ~= nil then
         return filteredConfig.categoryConfig[key]
-    elseif filteredConfig.typeConfig[key] ~= nil then
+    elseif filteredConfig.typeConfig?[key] ~= nil then
         return filteredConfig.typeConfig[key]
-    elseif filteredConfig.defaultConfig[key] ~= nil then
+    elseif filteredConfig.defaultConfig?[key] ~= nil then
         return filteredConfig.defaultConfig[key]
     else
         return default

--- a/shared/functions.lua
+++ b/shared/functions.lua
@@ -1,5 +1,6 @@
 local public = {}
 local config = require 'config.shared'
+local VEHICLES = exports.qbx_core:GetVehiclesByHash()
 
 --- Checks if the given two coordinates are close to each other based on distance.
 ---@param coord1 vector3[] The first set of coordinates.
@@ -68,6 +69,8 @@ end
 local function findConfigValue(filteredConfig, key, default)
     if filteredConfig.modelConfig[key] ~= nil then
         return filteredConfig.modelConfig[key]
+    elseif filteredConfig.categoryConfig[key] ~= nil then
+        return filteredConfig.categoryConfig[key]
     elseif filteredConfig.typeConfig[key] ~= nil then
         return filteredConfig.typeConfig[key]
     elseif filteredConfig.defaultConfig[key] ~= nil then
@@ -81,8 +84,10 @@ end
 ---@param vehicle number
 ---@return VehicleConfig
 function public.getVehicleConfig(vehicle)
+    local model = GetEntityModel(vehicle)
     local filteredConfig = {
-        modelConfig = config.vehicles.models[GetEntityModel(vehicle)],
+        modelConfig = config.vehicles.models[model],
+        categoryConfig = config.vehicles.categories[VEHICLES[model].category],
         typeConfig = config.vehicles.types[GetVehicleType(vehicle)],
         defaultConfig = config.vehicles.default
     }
@@ -92,6 +97,9 @@ function public.getVehicleConfig(vehicle)
     local carjackingImmune = findConfigValue(filteredConfig, 'carjackingImmune', false)
     local lockpickImmune = findConfigValue(filteredConfig, 'lockpickImmune', false)
     local shared = findConfigValue(filteredConfig, 'shared', false)
+    local removeNormalLockpickChance = findConfigValue(filteredConfig, 'removeNormalLockpickChance', 1.0)
+    local removeAdvancedLockpickChance = findConfigValue(filteredConfig, 'removeAdvancedLockpickChance', 1.0)
+    local findKeysChance = findConfigValue(filteredConfig, 'findKeysChance', 1.0)
 
     return {
         spawnLocked = spawnLocked,
@@ -99,6 +107,9 @@ function public.getVehicleConfig(vehicle)
         carjackingImmune = carjackingImmune,
         lockpickImmune = lockpickImmune,
         shared = shared,
+        removeNormalLockpickChance = removeNormalLockpickChance,
+        removeAdvancedLockpickChance = removeAdvancedLockpickChance,
+        findKeysChance = findKeysChance,
     }
 end
 

--- a/types.lua
+++ b/types.lua
@@ -1,11 +1,7 @@
 ---@meta
 
 ---@alias VehicleType 'automobile' | 'bike' | 'boat' | 'heli' | 'plane' | 'submarine' | 'trailer' | 'train'
-
----@class VehiclesConfig
----@field default VehicleConfig
----@field types table<VehicleType, VehicleConfig>
----@field models table<number, VehicleConfig>
+---@alias Hash number|string actually a number but `model` is treated as a string by language server
 
 ---@class VehicleConfig
 ---@field spawnLocked? boolean | number ratio 0.0 - 1.0
@@ -13,3 +9,6 @@
 ---@field carjackingImmune? boolean
 ---@field lockpickImmune? boolean
 ---@field shared? boolean
+---@field removeNormalLockpickChance number ratio
+---@field removeAdvancedLockpickChance number ratio
+---@field findKeysChance number ratio


### PR DESCRIPTION
Since VehicleClass is only accessible from the client, we'll use the vehicle's category from core config instead to apply vehicle config on. With this we'll also be moving config currently in client to shared to have the vehicle specific config in one place to make it clearer.

Also fixes a bug which was not checking for empty config tables