### PR TITLE
Patch

### DIFF
--- a/client/commands.lua
+++ b/client/commands.lua
@@ -36,7 +36,7 @@ local function giveKeys(id, plate)
     end
 end
 
-RegisterNetEvent('qb-vehiclekeys:client:GiveKeys', function(id, plate)
+local function handKeys(id, plate)
     local vehicle = plate and getVehicleByPlate(plate) or cache.vehicle or getVehicleInFront()
     if not vehicle then return end
     plate = plate or qbx.getVehiclePlate(vehicle)
@@ -56,4 +56,6 @@ RegisterNetEvent('qb-vehiclekeys:client:GiveKeys', function(id, plate)
         local playerId = lib.getClosestPlayer(GetEntityCoords(cache.ped), 3, false)
         giveKeys(playerId, plate)
     end
-end)
+end
+
+return handKeys

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -1,20 +1,6 @@
 local config = require 'config.client'
 local functions = require 'shared.functions'
-local getIsCloseToCoords = functions.getIsCloseToCoords
-local getIsBlacklistedWeapon = functions.getIsBlacklistedWeapon
-local getIsVehicleLockpickImmune = functions.getIsVehicleLockpickImmune
-local getIsVehicleCarjackingImmune = functions.getIsVehicleCarjackingImmune
-local getIsVehicleShared = functions.getIsVehicleShared
-
 local public = {}
-
-public.getIsVehicleCarjackingImmune = getIsVehicleCarjackingImmune -- to prevent circular-dependency error
-public.getIsBlacklistedWeapon = getIsBlacklistedWeapon
-public.getIsCloseToCoords = getIsCloseToCoords
-
-function public.getIsVehicleShared(vehicle)
-    return getIsVehicleShared(vehicle)
-end
 
 ---Grants keys for job shared vehicles
 ---@param vehicle number The entity number of the vehicle.
@@ -125,11 +111,9 @@ end
 local function getBoneCoords(entity, boneName)
     local boneIndex = GetEntityBoneIndexByName(entity, boneName)
 
-    if boneIndex ~= -1 then
-        return GetWorldPositionOfEntityBone(entity, boneIndex)
-    else
-        return GetEntityCoords(entity)
-    end
+    return boneIndex ~= -1
+        and GetWorldPositionOfEntityBone(entity, boneIndex)
+        or GetEntityCoords(entity)
 end
 
 ---Checks if any of the bones are close enough to the coords
@@ -141,7 +125,7 @@ end
 local function getIsCloseToAnyBone(coords, entity, bones, maxDistance)
     for i = 1, #bones do
         local boneCoords = getBoneCoords(entity, bones[i])
-        if getIsCloseToCoords(coords, boneCoords, maxDistance) then
+        if functions.getIsCloseToCoords(coords, boneCoords, maxDistance) then
             return true
         end
     end
@@ -227,7 +211,7 @@ function public.lockpickDoor(isAdvancedLockedpick, maxDistance, customChallenge)
     if not isDriverSeatFree -- no one in the driver's seat
         or not getIsCloseToAnyBone(pedCoords, vehicle, doorBones, maxDistance) -- the player's ped is close enough to the driver's door
         or GetVehicleDoorLockStatus(vehicle) < 2 -- the vehicle is locked
-        or getIsVehicleLockpickImmune(vehicle)
+        or functions.getIsVehicleLockpickImmune(vehicle)
     then return end
 
     local skillCheckConfig = config.skillCheck[isAdvancedLockedpick and 'advancedLockpick' or 'lockpick']

--- a/client/main.lua
+++ b/client/main.lua
@@ -175,8 +175,7 @@ local function onCarjackSuccess(occupants, vehicle)
     for p = 1, #occupants do
         local ped = occupants[p]
         CreateThread(function()
-            Wait(math.random(100, 500))
-            TaskLeaveVehicle(ped, vehicle, 0)
+            TaskLeaveVehicle(ped, vehicle, 256) -- flag 256 to leave door open
             PlayPain(ped, 6, 0)
             Wait(1250)
             PlayPain(ped, math.random(7, 8), 0)

--- a/client/main.lua
+++ b/client/main.lua
@@ -83,7 +83,7 @@ local function findKeys(vehicleModel, vehicleClass, plate, vehicle)
             combat = true,
         }
     }) then
-        if math.random() <= vehicleConfig.findKeysChance[vehicle] then
+        if math.random() <= vehicleConfig.findKeysChance then
             TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
             return true
         else

--- a/client/main.lua
+++ b/client/main.lua
@@ -152,6 +152,8 @@ local function makePedFlee(ped)
     ClearPedTasks(ped)
     SetPedFleeAttributes(ped, 0, false)
     TaskReactAndFleePed(ped, cache.ped)
+    TaskSmartFleePed(ped, cache.ped, 100.0, -1, false, false)
+    ResetPedLastVehicle(ped) -- make ped forget about his last car, so he cant return to it
 end
 
 local function makePedsPutHandsUpAndScream(occupants, vehicle)

--- a/client/main.lua
+++ b/client/main.lua
@@ -62,14 +62,10 @@ exports('SetVehicleDoorLock', setVehicleDoorLock)
 local function findKeys(vehicleModel, vehicleClass, plate, vehicle)
     local vehicleConfig = sharedFunctions.getVehicleConfig(vehicle)
     local hotwireTime = math.random(config.minKeysSearchTime, config.maxKeysSearchTime)
-    local scullyEmotes = GetResourceState('scully_emotemenu') == 'started'
 
     local anim = config.anims.lockpick.model[vehicleModel]
         or config.anims.lockpick.model[vehicleClass]
         or config.anims.lockpick.default
-    if scullyEmotes then
-        exports.scully_emotemenu:setLimitation(true)
-    end
     if lib.progressCircle({
         duration = hotwireTime,
         label = locale('progress.searching_keys'),
@@ -90,9 +86,6 @@ local function findKeys(vehicleModel, vehicleClass, plate, vehicle)
             TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
             exports.qbx_core:Notify(locale("notify.failed_keys"), 'error')
         end
-    end
-    if scullyEmotes then
-        exports.scully_emotemenu:setLimitation(false)
     end
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -229,6 +229,7 @@ local function carjackVehicle(driver, vehicle)
     }) then
         if cache.weapon and isCarjacking then
             local carjackChance = config.carjackChance[GetWeapontypeGroup(cache.weapon) --[[@as string]]] or 0.5
+            isCarjacking = false -- make this false to stop TaskVehicleTempAction from preventing ped to leave the car
 
             if math.random() <= carjackChance then
                 onCarjackSuccess(occupants, vehicle)

--- a/client/main.lua
+++ b/client/main.lua
@@ -385,8 +385,8 @@ AddEventHandler('ox_lib:cache:vehicle', function()
     showHotwiringLabel(cache.vehicle)
 end)
 
-lib.onCache('vehicle', function (vehicle) ---for some reason the autolock works with this
-end)
+-- lib.onCache('vehicle', function (vehicle) ---for some reason the autolock works with this
+-- end)
 
 for _, info in pairs(config.sharedKeys) do
     if info.enableAutolock then

--- a/client/main.lua
+++ b/client/main.lua
@@ -64,10 +64,14 @@ exports('SetVehicleDoorLock', setVehicleDoorLock)
 local function findKeys(vehicleModel, vehicleClass, plate, vehicle)
     local vehicleConfig = sharedFunctions.getVehicleConfig(vehicle)
     local hotwireTime = math.random(config.minKeysSearchTime, config.maxKeysSearchTime)
+    local scullyEmotes = GetResourceState('scully_emotemenu') == 'started'
 
     local anim = config.anims.lockpick.model[vehicleModel]
         or config.anims.lockpick.model[vehicleClass]
         or config.anims.lockpick.default
+    if scullyEmotes then
+        exports.scully_emotemenu:setLimitation(true)
+    end
     if lib.progressCircle({
         duration = hotwireTime,
         label = locale('progress.searching_keys'),
@@ -88,6 +92,9 @@ local function findKeys(vehicleModel, vehicleClass, plate, vehicle)
             TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
             exports.qbx_core:Notify(locale("notify.failed_keys"), 'error')
         end
+    end
+    if scullyEmotes then
+        exports.scully_emotemenu:setLimitation(false)
     end
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -414,6 +414,10 @@ AddEventHandler('onResourceStart', function(resourceName)
     end
 end)
 
+RegisterNetEvent('qb-vehiclekeys:client:GiveKeys', function(id, plate)
+    require 'client.commands'(id, plate) -- we load command module when we actually need it
+end)
+
 --#region Backwards Compatibility ONLY -- Remove at some point --
 RegisterNetEvent('qb-vehiclekeys:client:AddKeys', function(plate)
     TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)

--- a/client/main.lua
+++ b/client/main.lua
@@ -11,14 +11,15 @@ local toggleEngine = functions.toggleEngine
 local lockpickDoor = functions.lockpickDoor
 local areKeysJobShared = functions.areKeysJobShared
 local getVehicleInFront = functions.getVehicleInFront
-local getIsCloseToCoords = functions.getIsCloseToCoords
-local getIsVehicleShared = functions.getIsVehicleShared
 local getNPCPedsInVehicle = functions.getNPCPedsInVehicle
 local sendPoliceAlertAttempt = functions.sendPoliceAlertAttempt
 local getIsVehicleAccessible = functions.getIsVehicleAccessible
-local getIsBlacklistedWeapon = functions.getIsBlacklistedWeapon
+
+local getIsVehicleShared = sharedFunctions.getIsVehicleShared
+local getIsCloseToCoords = sharedFunctions.getIsCloseToCoords
+local getIsBlacklistedWeapon = sharedFunctions.getIsBlacklistedWeapon
 local getIsVehicleAlwaysUnlocked = sharedFunctions.getIsVehicleAlwaysUnlocked
-local getIsVehicleCarjackingImmune = functions.getIsVehicleCarjackingImmune
+local getIsVehicleCarjackingImmune = sharedFunctions.getIsVehicleCarjackingImmune
 
 -----------------------
 ----   Functions   ----
@@ -36,12 +37,9 @@ local function setVehicleDoorLock(vehicle, state, anim)
             lib.playAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3.0, 3.0, -1, 49)
         end
 
-        local lockstate
-        if state ~= nil then
-            lockstate = state and 2 or 1
-        else
-            lockstate = (GetVehicleDoorLockStatus(vehicle) % 2) + 1 -- (1 % 2) + 1 -> 2  (2 % 2) + 1 -> 1
-        end
+        local lockstate = state ~= nil
+            and (state and 2 or 1)
+            or (GetVehicleDoorLockStatus(vehicle) % 2) + 1 -- use ternary
 
         TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(vehicle), lockstate)
         exports.qbx_core:Notify(locale(lockstate == 2 and 'notify.vehicle_locked' or 'notify.vehicle_unlocked'))

--- a/config/client.lua
+++ b/config/client.lua
@@ -157,10 +157,6 @@ return {
                 [VehicleClass.SEDANS]          = normalLockpickSkillCheck,
                 [VehicleClass.SUVS]            = normalLockpickSkillCheck,
                 [VehicleClass.COUPES]          = normalLockpickSkillCheck,
-                [VehicleClass.COMPACTS]        = normalLockpickSkillCheck,
-                [VehicleClass.SEDANS]          = normalLockpickSkillCheck,
-                [VehicleClass.SUVS]            = normalLockpickSkillCheck,
-                [VehicleClass.COUPES]          = normalLockpickSkillCheck,
                 [VehicleClass.MUSCLE]          = normalLockpickSkillCheck,
                 [VehicleClass.SPORTS_CLASSICS] = normalLockpickSkillCheck,
                 [VehicleClass.SPORTS]          = normalLockpickSkillCheck,
@@ -219,10 +215,6 @@ return {
         hotwire = {
             default = normalLockpickSkillCheck,
             class = {
-                [VehicleClass.COMPACTS]        = normalLockpickSkillCheck,
-                [VehicleClass.SEDANS]          = normalLockpickSkillCheck,
-                [VehicleClass.SUVS]            = normalLockpickSkillCheck,
-                [VehicleClass.COUPES]          = normalLockpickSkillCheck,
                 [VehicleClass.COMPACTS]        = normalLockpickSkillCheck,
                 [VehicleClass.SEDANS]          = normalLockpickSkillCheck,
                 [VehicleClass.SUVS]            = normalLockpickSkillCheck,

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -19,16 +19,33 @@ return {
             findKeysChance = 0.5,
         },
         ---@type table<string, VehicleConfig>
-        categories = {
-
+        categories = { -- known categories: super, service, utility, helicopters, motorcycles, suvs, planes, sports, emergency, military, sportsclassics, compacts, sedans
+            -- super = {
+            --     noLock = false,
+            --     spawnLocked = 1.0,
+            --     carjackingImmune = false,
+            --     lockpickImmune = false,
+            --     shared = false,
+            --     removeNormalLockpickChance = 1.0,
+            --     removeAdvancedLockpickChance = 1.0,
+            --     findKeysChance = 0.5,
+            -- }
         },
         ---@type table<VehicleType, VehicleConfig>
-        types = {
-
+        types = { -- known types: automobile, bike, boat, heli, plane, submarine, trailer, train
+            -- automobile = {
+            --     noLock = false,
+            --     spawnLocked = 1.0,
+            --     carjackingImmune = false,
+            --     lockpickImmune = false,
+            --     shared = false,
+            --     removeNormalLockpickChance = 1.0,
+            --     removeAdvancedLockpickChance = 1.0,
+            --     findKeysChance = 0.5,
+            -- }
         },
         ---@type table<Hash, VehicleConfig>
         models = {
-            -- Example:
             -- [`stockade`] = {
             --     spawnLocked = 0.5
             -- }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -10,20 +10,21 @@ ox_lib 'locale'
 shared_scripts {
     '@ox_lib/init.lua',
     '@qbx_core/modules/lib.lua',
-    'shared/*.lua'
 }
 
 client_scripts {
     '@qbx_core/modules/playerdata.lua',
-    'client/*.lua'
+    'client/main.lua'
 }
 
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
-    'server/*.lua'
+    'server/main.lua'
 }
 
 files {
+    'client/*.lua',
+    'shared/*.lua',
     'locales/*.json',
     'config/client.lua',
     'config/shared.lua'

--- a/server/main.lua
+++ b/server/main.lua
@@ -71,6 +71,8 @@ AddEventHandler('entityCreated', function (entity)
 
     local vehicle = type == EntityType.Ped and GetVehiclePedIsIn(entity, false) or entity
 
+    if not DoesEntityExist(vehicle) then return end -- ped can be not in vehicle, so we need to check if vehicle is a entity, otherwise it will return 0
+
     local chance = math.random()
     local isLocked = (getIsVehicleInitiallyLocked(vehicle)
             or (type == EntityType.Ped and chance < config.lockNPCDrivenCarsChance)


### PR DESCRIPTION
## Description

#### This fixes most issues in [94](https://github.com/Qbox-project/qbx_vehiclekeys/issues/94)
- hot wiring/searching for keys causes ped to leave car occasionally (need [78](https://github.com/Scullyy/scully_emotemenu/pull/78) merge), after retesting without changes i made in scully emotes and only kept this [change](https://github.com/Qbox-project/qbx_vehiclekeys/commit/3f2487139a0999ca165ed2dc8583083d5a9eebf3) the issue still, so i reverted
- Carjacking ped will just return to their car once car jack is done, ped should run away in fear
- Ped can be carjacked over and over with no limit (just keep aiming over and over)
- Ped instantaneously pops out of the car when being jacked, stands there in an A pose, doesn't put hands up consistently
#### Some code [Improvements ](https://github.com/Qbox-project/qbx_vehiclekeys/commit/5295950a14e02d8575b29ae7738177ca6bc746f6)
- [Duplicated config indexes](https://github.com/Qbox-project/qbx_vehiclekeys/commit/70d1370c32703bb67cc14cd767cb0a4f9e3b78f0)
- [Add known vehicle types/categories notes](https://github.com/Qbox-project/qbx_vehiclekeys/commit/8d73404fb1fd09d7a7aa7b3cf565513d28378572)
- [Prevent file from running twice](https://github.com/Qbox-project/qbx_vehiclekeys/commit/7127dcf301f2b83e148fb0b6c4dc1a42cfcd591a)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
