### PR TITLE
feat(hotwiring): disable INPUT_VEH_ACCELERATE when no keys

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -123,6 +123,7 @@ local function showHotwiringLabel(vehicle)
                 setSearchLabelState(true)
                 while not isVehicleAccessible and cache.seat == -1 do
                     SetVehicleEngineOn(cache.vehicle, false, true, true)
+                    DisableControlAction(0, 71, true)
                     Wait(0)
                     isVehicleAccessible = getIsVehicleAccessible(vehicle, plate)
                 end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Prevents animation error when no keys.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
