### PR TITLE
fix: allow searching keys only when in drivers seat and prevent bypassing cooldown

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -98,7 +98,7 @@ local function setSearchLabelState(isAllowed)
     local isValidMessage = text and text == newText
     if isAllowed and not isValidMessage and cache.seat == -1 then
         lib.showTextUI(newText)
-    elseif (not isAllowed or not cache.seat == -1) and isOpen and isValidMessage then
+    elseif (not isAllowed or cache.seat ~= -1) and isOpen and isValidMessage then
         lib.hideTextUI()
     end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -94,13 +94,13 @@ local function setSearchLabelState(isAllowed)
     local isOpen, text = lib.isTextUIOpen()
     local newText = locale('info.search_keys_dispatch')
     local isValidMessage = text and text == newText
-    if isAllowed and not isValidMessage then
+    if isAllowed and not isValidMessage and cache.seat == -1 then
         lib.showTextUI(newText)
-    elseif not isAllowed and isOpen and isValidMessage then
+    elseif (not isAllowed or not cache.seat == -1) and isOpen and isValidMessage then
         lib.hideTextUI()
     end
 
-    isSearchAllowed = isAllowed
+    isSearchAllowed = isAllowed and cache.seat == -1
 end
 
 local isShowHotwiringLabelRunning = false

--- a/client/main.lua
+++ b/client/main.lua
@@ -89,8 +89,10 @@ local function findKeys(vehicleModel, vehicleClass, plate, vehicle)
     end
 end
 
+local isSearchLocked = false
 local isSearchAllowed = false
 local function setSearchLabelState(isAllowed)
+    if isSearchLocked and isAllowed then return end
     local isOpen, text = lib.isTextUIOpen()
     local newText = locale('info.search_keys_dispatch')
     local isValidMessage = text and text == newText
@@ -310,6 +312,7 @@ lib.addKeybind({
     secondaryKey = 'LRIGHT_INDEX',
     onPressed = function()
         if isSearchAllowed and cache.vehicle then
+            isSearchLocked = true
             setSearchLabelState(false)
             local vehicle = cache.vehicle
             local plate = qbx.getVehiclePlate(vehicle)
@@ -321,6 +324,7 @@ lib.addKeybind({
                 end)
             end
             Wait(config.timeBetweenHotwires)
+            isSearchLocked = false
             setSearchLabelState(not isFound)
         end
     end


### PR DESCRIPTION
This fixes an issue where the search keys text UI would display when outside the vehicle, and the cooldown could be bypassed early resulting in multiple progress bars at the same time.

Repro steps:

1. Search for keys
2. Fail the search and immediately get out
3. Get back in to bypass the cooldown and start searching for keys again or stay outside and observe the text UI would pop up again even though the player is now outside the vehicle