### PR TITLE
fix(shared/functions): pass model hash to `GetVehicleClass` export

### DIFF
--- a/shared/functions.lua
+++ b/shared/functions.lua
@@ -92,7 +92,7 @@ end
 ---@return VehicleConfig
 function public.getVehicleConfig(vehicle)
     local model = GetEntityModel(vehicle)
-    local class = IsDuplicityVersion() and exports.qbx_core:GetVehicleClass(vehicle) or GetVehicleClass(vehicle)
+    local class = IsDuplicityVersion() and exports.qbx_core:GetVehicleClass(model) or GetVehicleClass(vehicle)
     local filteredConfig = {
         modelConfig = config.vehicles.models[model],
         categoryConfig = config.vehicles.categories[VEHICLES[model]?.category],


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Passes a model hash instead of a vehicle ID to the server-side `GetVehicleClass` since that's what it accepts.

Blocked by Qbox-project/qbx_core#571.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
