### PR TITLE
fix: correct lockpick anim, notify when unlocked, added statebaghandler for doorlocks

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -207,10 +207,11 @@ function public.lockpickDoor(isAdvancedLockedpick, maxDistance, customChallenge)
 
     local isDriverSeatFree = IsVehicleSeatFree(vehicle, -1)
 
+    if GetVehicleDoorLockStatus(vehicle) < 2 then exports.qbx_core:Notify(locale('notify.vehicle_is_unlocked'), 'error') return end
+
     --- player may attempt to open the lock if:
     if not isDriverSeatFree -- no one in the driver's seat
         or not getIsCloseToAnyBone(pedCoords, vehicle, doorBones, maxDistance) -- the player's ped is close enough to the driver's door
-        or GetVehicleDoorLockStatus(vehicle) < 2 -- the vehicle is locked
         or functions.getIsVehicleLockpickImmune(vehicle)
     then return end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -416,6 +416,11 @@ if config.carjackEnable then
     end)
 end
 
+qbx.entityStateHandler('doorslockstate', function(entity, _, value)
+    if entity == 0 then return end
+    SetVehicleDoorsLocked(entity, value)
+end)
+
 AddEventHandler('onResourceStart', function(resourceName)
     if (GetCurrentResourceName() ~= resourceName) then return end
 

--- a/config/client.lua
+++ b/config/client.lua
@@ -32,7 +32,7 @@ local defaultHotwireAnim = { dict = 'anim@veh@plane@howard@front@ds@base', clip 
 local defaultSearchKeysAnim = { dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@', clip = 'machinic_loop_mechandplayer' }
 
 ---@type Anim
-local defaultLockpickAnim = { dict = 'anim@mp_player_intmenu@key_fob@', clip = 'fob_click' }
+local defaultLockpickAnim = { dict = 'veh@break_in@0h@p_m_one@', clip = 'low_force_entry_ds' }
 
 ---@type Anim
 local defaultHoldupAnim = { dict = 'mp_am_hold_up', clip = 'holdup_victim_20s' }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -11,13 +11,13 @@ return {
         ---@type VehicleConfig
         default = {
             noLock = false,
-            spawnLockedIfParked = .75,
-            spawnLockedIfDriven = .75,
+            spawnLockedIfParked = 0.75,
+            spawnLockedIfDriven = 0.75,
             carjackingImmune = false,
             lockpickImmune = false,
             shared = false,
-            removeNormalLockpickChance = 1.0,
-            removeAdvancedLockpickChance = 1.0,
+            removeNormalLockpickChance = 0.4,
+            removeAdvancedLockpickChance = 0.2,
             findKeysChance = 0.5,
         },
         ---@type table<VehicleClass, VehicleConfig>

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -40,7 +40,8 @@
     "vehicle_unlocked": "Vozidlo odemčeno!",
     "removed_keys": "The keys to plate %s for player %s have been removed!",
     "removed_keys_player": "Your keys to plate %s have been removed!",
-    "player_offline": "This player is not online!"
+    "player_offline": "This player is not online!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Pokus o krádež auta...",

--- a/locales/da.json
+++ b/locales/da.json
@@ -42,7 +42,8 @@
     "vehicle_unlocked": "Køretøj ulåst!",
     "removed_keys": "Nøglerne til nummerplade %s for spiller %s er blevet fjernet!",
     "removed_keys_player": "Dine nøgler til nummerplade %s er blevet fjernet!",
-    "player_offline": "Denne spiller er ikke online!"
+    "player_offline": "Denne spiller er ikke online!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Forsøger at kapre køretøjet...",

--- a/locales/de.json
+++ b/locales/de.json
@@ -40,7 +40,8 @@
     "vehicle_unlocked": "Fahrzeug entriegelt.",
     "removed_keys": "The keys to plate %s for player %s have been removed!",
     "removed_keys_player": "Your keys to plate %s have been removed!",
-    "player_offline": "This player is not online!"
+    "player_offline": "This player is not online!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Versuchter Autodiebstahl...",

--- a/locales/en.json
+++ b/locales/en.json
@@ -42,7 +42,8 @@
     "vehicle_unlocked": "Vehicle unlocked!",
     "removed_keys": "The keys to plate %s for player %s have been removed!",
     "removed_keys_player": "Your keys to plate %s have been removed!",
-    "player_offline": "This player is not online!"
+    "player_offline": "This player is not online!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Attempting Carjacking...",

--- a/locales/es.json
+++ b/locales/es.json
@@ -40,7 +40,8 @@
     "vehicle_unlocked": "Vehículo abierto",
     "removed_keys": "The keys to plate %s for player %s have been removed!",
     "removed_keys_player": "Your keys to plate %s have been removed!",
-    "player_offline": "This player is not online!"
+    "player_offline": "This player is not online!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Intentando robar carro...",

--- a/locales/et.json
+++ b/locales/et.json
@@ -40,7 +40,8 @@
     "vehicle_unlocked": "Sõiduk avatud!",
     "removed_keys": "The keys to plate %s for player %s have been removed!",
     "removed_keys_player": "Your keys to plate %s have been removed!",
-    "player_offline": "This player is not online!"
+    "player_offline": "This player is not online!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Autovarguse katse...",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -40,7 +40,8 @@
     "vehicle_unlocked": "Véhicule déverrouillé!",
     "removed_keys": "The keys to plate %s for player %s have been removed!",
     "removed_keys_player": "Your keys to plate %s have been removed!",
-    "player_offline": "This player is not online!"
+    "player_offline": "This player is not online!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Tentative de vol de carjack..",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -40,7 +40,8 @@
     "vehicle_unlocked": "Voertuig van het slot gehaald!",
     "removed_keys": "De sleutels voor het voertuig met kenteken %s voor speler %s zijn afgenomen!",
     "removed_keys_player": "De sleutels voor het voertuig met kenteken %s zijn van je afgenomen!",
-    "player_offline": "Deze speler is niet online!"
+    "player_offline": "Deze speler is niet online!",
+	"vehicle_is_unlocked": "Voertuig staat niet op slot!"
   },
   "progress": {
     "attempting_carjack": "Voertuig Stelen...",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -40,7 +40,8 @@
     "vehicle_unlocked": "Veículo destrancado!",
     "removed_keys": "The keys to plate %s for player %s have been removed!",
     "removed_keys_player": "Your keys to plate %s have been removed!",
-    "player_offline": "This player is not online!"
+    "player_offline": "This player is not online!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Tentativa de assalto ao veículo...",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -40,7 +40,8 @@
     "vehicle_unlocked": "Vehicul deblocat - Alarma inactiva!",
     "removed_keys": "The keys to plate %s for player %s have been removed!",
     "removed_keys_player": "Your keys to plate %s have been removed!",
-    "player_offline": "This player is not online!"
+    "player_offline": "This player is not online!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Incerci sa fur vehiculul...",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -40,7 +40,8 @@
     "vehicle_unlocked": "Araç açık",
     "removed_keys": "Plakalı %s aracın oyuncu %s'ye ait anahtarları alındı!",
     "removed_keys_player": "Plakalı %s araca ait anahtarlarınız alındı!",
-    "player_offline": "Bu oyuncu çevrimdışı!"
+    "player_offline": "Bu oyuncu çevrimdışı!",
+	"vehicle_is_unlocked": "Vehicle is already unlocked!"
   },
   "progress": {
     "attempting_carjack": "Araç hırsızlığı deneniyor...",

--- a/server/main.lua
+++ b/server/main.lua
@@ -37,7 +37,9 @@ RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
 end)
 
 RegisterNetEvent('qb-vehiclekeys:server:setVehLockState', function(vehNetId, state)
-    SetVehicleDoorsLocked(NetworkGetEntityFromNetworkId(vehNetId), state)
+    local vehicle = NetworkGetEntityFromNetworkId(vehNetId)
+    SetVehicleDoorsLocked(vehicle, state)
+    Entity(vehicle).state:set('doorslockstate', state, true)
 end)
 
 RegisterNetEvent('QBCore:Server:OnPlayerLoaded', function()

--- a/server/main.lua
+++ b/server/main.lua
@@ -37,9 +37,9 @@ RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
 end)
 
 RegisterNetEvent('qb-vehiclekeys:server:setVehLockState', function(vehNetId, state)
-    local vehicle = NetworkGetEntityFromNetworkId(vehNetId)
-    SetVehicleDoorsLocked(vehicle, state)
-    Entity(vehicle).state:set('doorslockstate', state, true)
+	local vehicleEntity = NetworkGetEntityFromNetworkId(vehNetId)
+	if type(state) ~= 'number' or not DoesEntityExist(vehicleEntity) then return end
+    Entity(vehicleEntity).state:set('doorslockstate', state, true)
 end)
 
 RegisterNetEvent('QBCore:Server:OnPlayerLoaded', function()


### PR DESCRIPTION
## Description
When finishing lockpicking sometimes it is confusing if you miss the success message, now it will tel you it is already unlocked.
Added statebaghandler vehicle doorlocks state for better redundancy as the server-sided native is sometimes unreliable.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
