### PR TITLE
fix: don't allow locking a vehicle without a lock

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -418,6 +418,9 @@ end
 
 qbx.entityStateHandler('doorslockstate', function(entity, _, value)
     if entity == 0 then return end
+    if getIsVehicleShared(entity) then
+        value = 1
+    end
     SetVehicleDoorsLocked(entity, value)
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -418,9 +418,6 @@ end
 
 qbx.entityStateHandler('doorslockstate', function(entity, _, value)
     if entity == 0 then return end
-    if getIsVehicleShared(entity) then
-        value = 1
-    end
     SetVehicleDoorsLocked(entity, value)
 end)
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -6,6 +6,7 @@ local addPlayer = functions.addPlayer
 local removePlayer = functions.removePlayer
 local getIsVehicleAlwaysUnlocked = sharedFunctions.getIsVehicleAlwaysUnlocked
 local getIsVehicleInitiallyLocked = sharedFunctions.getIsVehicleInitiallyLocked
+local getIsVehicleShared = sharedFunctions.getIsVehicleShared
 
 ---@enum EntityType
 local EntityType = {
@@ -39,6 +40,7 @@ end)
 RegisterNetEvent('qb-vehiclekeys:server:setVehLockState', function(vehNetId, state)
 	local vehicleEntity = NetworkGetEntityFromNetworkId(vehNetId)
 	if type(state) ~= 'number' or not DoesEntityExist(vehicleEntity) then return end
+    if getIsVehicleAlwaysUnlocked(vehicleEntity) or getIsVehicleShared(vehicleEntity) then return end
     Entity(vehicleEntity).state:set('doorslockstate', state, true)
 end)
 


### PR DESCRIPTION
This adds a check that someone isn't trying to toggle the locks of a vehicle without locks.