### PR TITLE
fix(client/functions): guard against vehicle not existing during raycast

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -79,7 +79,7 @@ function public.getVehicleInFront()
     for i = 1, #raycastOffsetTable do
         local vehicle = getVehicleInDirection(raycastOffsetTable[i]['fromOffset'], raycastOffsetTable[i]['toOffset'])
 
-        if IsEntityAVehicle(vehicle) then
+        if vehicle and DoesEntityExist(vehicle) and IsEntityAVehicle(vehicle) then
             return vehicle
         end
     end


### PR DESCRIPTION
Observed an error executing IsEntityAVehicle function. Suspect it is due to a nil entity value, so adding this check.