### PR TITLE
fix: apply correct plate in access if changed after spawn

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -31,7 +31,12 @@ exports('HasKeys', public.hasKeys)
 ---@param plate string? The plate number of the vehicle.
 ---@return boolean? `true` if player has access to the vehicle, `nil` otherwise.
 function public.getIsVehicleAccessible(vehicle, plate)
-    plate = plate or qbx.getVehiclePlate(vehicle)
+    local qbxPlate = qbx.getVehiclePlate(vehicle) -- Define local variable rather than call twice
+    plate = plate or qbxPlate
+    if plate ~= qbxPlate then -- Double check if plate matches (Sometimes only uses plate from inital spawn, instead of updated plate, breaking this e.g. JG scripts like garages & dealerships)
+        plate = qbxPlate
+    end
+
     return public.hasKeys(plate) or public.areKeysJobShared(vehicle)
 end
 


### PR DESCRIPTION
## Description

Resolves an issue caused when a vehicle is spawned and then the plate is changed.

Essentially when a vehicle is initiailly spawned and the hotwire check is ran, the original vehicles plate is passed, however if the plate is updated by an external resource such as a personal vehicle from a garage, it doesn't process this always showing as no key access.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
