### PR TITLE
feat: toggle locks via distance check rather than raycast

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -10,7 +10,6 @@ local hotwire = functions.hotwire
 local toggleEngine = functions.toggleEngine
 local lockpickDoor = functions.lockpickDoor
 local areKeysJobShared = functions.areKeysJobShared
-local getVehicleInFront = functions.getVehicleInFront
 local sendPoliceAlertAttempt = functions.sendPoliceAlertAttempt
 local getIsVehicleAccessible = functions.getIsVehicleAccessible
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -161,7 +161,8 @@ togglelocksBind = lib.addKeybind({
     defaultKey = 'L',
     onPressed = function()
         togglelocksBind:disable(true)
-        setVehicleDoorLock(getVehicleInFront(), nil, true)
+        local vehicle = lib.getClosestVehicle(GetEntityCoords(cache.ped), config.vehicleMaximumLockingDistance, true)
+        setVehicleDoorLock(vehicle, nil, true)
         Wait(1000)
         togglelocksBind:disable(false)
     end


### PR DESCRIPTION
It's a better experience for players to do a distance check so they can get out of the car and lock the vehicle rather than turn around and make sure they face the vehicle first.