### PR TITLE
refactor: remove acquirevehiclekeys event

### DIFF
--- a/client/carjack.lua
+++ b/client/carjack.lua
@@ -52,15 +52,11 @@ local function onCarjackSuccess(occupants, vehicle)
             makePedFlee(ped)
         end)
     end
-    TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
-    TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(vehicle), 1)
-    TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', VehToNet(vehicle))
 end
 
 local function onCarjackFail(driver)
     exports.qbx_core:Notify(locale('notify.carjack_failed'), 'error')
     makePedFlee(driver)
-    TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
 end
 
 local function carjackVehicle(driver, vehicle)
@@ -98,14 +94,14 @@ local function carjackVehicle(driver, vehicle)
         },
     }) then
         if cache.weapon and isCarjacking then
-            local carjackChance = config.carjackChance[GetWeapontypeGroup(cache.weapon) --[[@as string]]] or 0.5
             isCarjacking = false -- make this false to stop TaskVehicleTempAction from preventing ped to leave the car
-
-            if math.random() <= carjackChance then
+            local success = lib.callback.await('qbx_vehiclekeys:server:carjack', false, VehToNet(vehicle), GetWeapontypeGroup(cache.weapon))
+            if success then
                 onCarjackSuccess(occupants, vehicle)
             else
                 onCarjackFail(driver)
             end
+            TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
             Wait(2000)
             sendPoliceAlertAttempt('carjack')
         end

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -227,7 +227,7 @@ end
 ---Will be executed when the lock opening is successful.
 ---@param vehicle number The entity number of the vehicle.
 local function hotwireSuccessCallback(vehicle)
-    TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', VehToNet(vehicle))
+    TriggerServerEvent('qbx_vehiclekeys:server:hotwiredVehicle', VehToNet(vehicle))
 end
 
 ---Operations done after the LockpickDoor quickevent done.

--- a/config/client.lua
+++ b/config/client.lua
@@ -48,19 +48,6 @@ return {
     carjackEnable = true,                -- Enables the ability to carjack pedestrian vehicles, stealing them by pointing a weapon at them
     carjackingTimeInMs = 7500,           -- Time it takes to successfully carjack in miliseconds
     delayBetweenCarjackingsInMs = 10000, -- Time before you can attempt another carjack in miliseconds
-    ---@type table<VehicleClass, number>
-    carjackChance = {                    -- Probability of successful carjacking based on weapon used
-        [WeaponTypeGroup.MELEE] = 0.0,
-        [WeaponTypeGroup.HANDGUN] = 0.5,
-        [WeaponTypeGroup.SMG] = 0.75,
-        [WeaponTypeGroup.SHOTGUN] = 0.90,
-        [WeaponTypeGroup.RIFLE] = 0.90,
-        [WeaponTypeGroup.LMG] = 0.99,
-        [WeaponTypeGroup.SNIPER] = 0.99,
-        [WeaponTypeGroup.HEAVY] = 0.99,
-        [WeaponTypeGroup.THROWABLE] = 0.0,
-        [WeaponTypeGroup.MISC] = 0.0,
-    },
 
     -- Hotwire Settings
     timeBetweenHotwires = 5000, -- Time in milliseconds between hotwire attempts

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,3 +1,16 @@
 return {
     runClearCronMinutes = 5,
+    ---@type table<WeaponTypeGroup, number>
+    carjackChance = {                    -- Probability of successful carjacking based on weapon used
+        [WeaponTypeGroup.MELEE] = 0.0,
+        [WeaponTypeGroup.HANDGUN] = 0.5,
+        [WeaponTypeGroup.SMG] = 0.75,
+        [WeaponTypeGroup.SHOTGUN] = 0.90,
+        [WeaponTypeGroup.RIFLE] = 0.90,
+        [WeaponTypeGroup.LMG] = 0.99,
+        [WeaponTypeGroup.SNIPER] = 0.99,
+        [WeaponTypeGroup.HEAVY] = 0.99,
+        [WeaponTypeGroup.THROWABLE] = 0.0,
+        [WeaponTypeGroup.MISC] = 0.0,
+    },
 }

--- a/server/keys.lua
+++ b/server/keys.lua
@@ -1,7 +1,13 @@
 local config = require 'config.server'
 local debug = GetConvarInt(('%s-debug'):format(GetCurrentResourceName()), 0) == 1
 
+---@alias CitizenId string
+---@alias SessionId integer
+---@type table<CitizenId, table<SessionId, boolean>>
 local keysList = {} ---holds key status for some time after player logs out (Prevents frustration by crashing the client)
+
+---@alias LogoutTime integer
+---@type table<CitizenId, LogoutTime>
 local keysLifetime = {} ---Life timestamp of the keys of a character who has logged out
 
 ---Gets Citizen Id based on source

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,3 +1,4 @@
+local config = require 'config.server'
 local sharedFunctions = require 'shared.functions'
 
 local getIsVehicleAlwaysUnlocked = sharedFunctions.getIsVehicleAlwaysUnlocked
@@ -12,7 +13,38 @@ local EntityType = {
     Object = 3
 }
 
-RegisterNetEvent('qb-vehiclekeys:server:AcquireVehicleKeys', function(netId)
+lib.callback.register('qbx_vehiclekeys:server:findKeys', function(source, netId)
+    local vehicle = NetworkGetEntityFromNetworkId(netId)
+    if math.random() <= sharedFunctions.getVehicleConfig(vehicle).findKeysChance then
+        GiveKeys(source, vehicle)
+        return true
+    end
+end)
+
+lib.callback.register('qbx_vehiclekeys:server:carjack', function(source, netId, weaponTypeGroup)
+    local chance = config.carjackChance[weaponTypeGroup] or 0.5
+    if math.random() <= chance then
+        local vehicle = NetworkGetEntityFromNetworkId(netId)
+        GiveKeys(source, vehicle)
+        TriggerEvent('qb-vehiclekeys:server:setVehLockState', netId, 1)
+        return true
+    end
+end)
+
+RegisterNetEvent('qbx_vehiclekeys:server:playerEnteredVehicleWithEngineOn', function(netId)
+    local src = source
+    local vehicle = NetworkGetEntityFromNetworkId(netId)
+    if not GetIsVehicleEngineRunning(vehicle) then return end
+    GiveKeys(src, vehicle)
+end)
+
+---TODO: secure this event
+RegisterNetEvent('qbx_vehiclekeys:server:tookKeys', function(netId)
+    GiveKeys(source, NetworkGetEntityFromNetworkId(netId))
+end)
+
+---TODO: secure this event
+RegisterNetEvent('qbx_vehiclekeys:server:hotwiredVehicle', function(netId)
     GiveKeys(source, NetworkGetEntityFromNetworkId(netId))
 end)
 


### PR DESCRIPTION
Want to move towards a world where we only modify vehicle keys on the server for security purposes.

This PR removes the acquire vehicle keys event and changes all the internal callers to use other means such as callbacks, or more specific events.