### PR TITLE
feat: qb-vehiclekeys bridge

### DIFF
--- a/bridge/qb/client.lua
+++ b/bridge/qb/client.lua
@@ -1,0 +1,13 @@
+if GetConvar('qbx_vehiclekeys:enableBridge', 'true') ~= 'true' then return end
+
+RegisterNetEvent('qb-vehiclekeys:client:AddKeys', function(plate)
+    TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
+end)
+
+RegisterNetEvent('qb-vehiclekeys:client:RemoveKeys', function(plate)
+    TriggerServerEvent('qb-vehiclekeys:server:removeKeys', plate)
+end)
+
+RegisterNetEvent('vehiclekeys:client:SetOwner', function(plate)
+    TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
+end)

--- a/bridge/qb/server.lua
+++ b/bridge/qb/server.lua
@@ -1,0 +1,29 @@
+if GetConvar('qbx_vehiclekeys:enableBridge', 'true') ~= 'true' then return end
+
+local function giveKeys(source, plate)
+    local vehicles = plate and GetVehiclesFromPlate(plate) or {GetVehiclePedIsIn(GetPlayerPed(source), false)}
+    local success = nil
+    for i = 1, #vehicles do
+        success = success or GiveKeys(source, vehicles[i])
+    end
+    return success
+end
+
+CreateQbExport('GiveKeys', giveKeys)
+
+local function removeKeys(source, plate)
+    local vehicles = GetVehiclesFromPlate(plate)
+    for i = 1, #vehicles do
+        RemoveKeys(source, vehicles[i])
+    end
+end
+
+CreateQbExport('RemoveKeys', removeKeys)
+
+RegisterNetEvent('qb-vehiclekeys:server:AcquireVehicleKeys', function(plate)
+    giveKeys(source, plate)
+end)
+
+RegisterNetEvent('qb-vehiclekeys:server:removeKeys', function(plate)
+    removeKeys(source, plate)
+end)

--- a/bridge/qb/shared.lua
+++ b/bridge/qb/shared.lua
@@ -1,0 +1,31 @@
+if GetConvar('qbx_vehiclekeys:enableBridge', 'true') ~= 'true' then return end
+
+function CreateQbExport(name, cb)
+    AddEventHandler(('__cfx_export_qb-vehiclekeys_%s'):format(name), function(setCB)
+        setCB(cb)
+    end)
+end
+
+function GetVehiclesFromPlate(plate)
+    local vehicles = GetAllVehicles()
+    local vehEntityFromPlate = {}
+
+    for i = 1, #vehicles do
+        local vehicle = vehicles[i]
+        local vehPlate = qbx.getVehiclePlate(vehicle)
+        if plate == vehPlate then
+            vehEntityFromPlate[#vehEntityFromPlate + 1] = vehicle
+        end
+    end
+
+    return vehEntityFromPlate
+end
+
+CreateQbExport('HasKeys', function(source, plate)
+    local vehicles = GetVehiclesFromPlate(plate)
+    local success = nil
+    for i = 1, #vehicles do
+        success = success or HasKeys(source, vehicles[i])
+    end
+    return success
+end)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -19,19 +19,19 @@ end
 ---Checks if player has vehicle keys
 ---@param vehicle number
 ---@return boolean? `true` if player has vehicle keys, `nil` otherwise.
-function public.hasKeys(vehicle)
+function HasKeys(vehicle)
     local keysList = LocalPlayer.state.keysList or {}
     local sessionId = Entity(vehicle).state.sessionId
     return keysList[sessionId]
 end
 
-exports('HasKeys', public.hasKeys)
+exports('HasKeys', HasKeys)
 
 ---Checks if player has vehicle keys of or access to the vehicle is provided as part of his job.
 ---@param vehicle number The entity number of the vehicle.
 ---@return boolean? `true` if player has access to the vehicle, `nil` otherwise.
 function public.getIsVehicleAccessible(vehicle)
-    return public.hasKeys(vehicle) or public.areKeysJobShared(vehicle)
+    return HasKeys(vehicle) or public.areKeysJobShared(vehicle)
 end
 
 function public.toggleEngine(vehicle)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,12 +11,14 @@ shared_scripts {
     '@ox_lib/init.lua',
     '@qbx_core/modules/lib.lua',
     'shared/types.lua',
+    'bridge/qb/shared.lua',
 }
 
 client_scripts {
     '@qbx_core/modules/playerdata.lua',
     'client/main.lua',
     'client/carjack.lua',
+    'bridge/qb/client.lua',
 }
 
 server_scripts {
@@ -24,12 +26,13 @@ server_scripts {
     'server/version.lua',
     'server/keys.lua',
     'server/main.lua',
-    'server/commands.lua'
+    'server/commands.lua',
+    'bridge/qb/server.lua',
 }
 
 files {
-    'client/*.lua',
-    'shared/*.lua',
+    'client/functions.lua',
+    'shared/functions.lua',
     'locales/*.json',
     'config/client.lua',
     'config/shared.lua'
@@ -37,3 +40,4 @@ files {
 
 lua54 'yes'
 use_experimental_fxv2_oal 'yes'
+provide 'qb-vehiclekeys'

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -1,15 +1,4 @@
 ---@param src number
----@param vehicle number
----@return boolean
-local function hasKeys(src, vehicle)
-    local keysList = Player(src).state.keysList or {}
-    local sessionId = Entity(vehicle).state.sessionId
-    return keysList[sessionId]
-end
-
-exports('HasKeys', hasKeys)
-
----@param src number
 ---@return number?
 local function getClosestPlayer(src)
     local playerCoords = GetEntityCoords(GetPlayerPed(src))
@@ -39,7 +28,7 @@ local function transferKeys(source, target, enforceSrcHasKeys)
         exports.qbx_core:Notify(source, locale('notify.vehicle_not_near'), 'error')
         return
     end
-    if enforceSrcHasKeys and not hasKeys(source, vehicle) then
+    if enforceSrcHasKeys and not HasKeys(source, vehicle) then
         exports.qbx_core:Notify(source, locale('notify.no_keys'), 'error')
         return
     end

--- a/server/keys.lua
+++ b/server/keys.lua
@@ -4,11 +4,11 @@ local debug = GetConvarInt(('%s-debug'):format(GetCurrentResourceName()), 0) == 
 ---@alias CitizenId string
 ---@alias SessionId integer
 ---@type table<CitizenId, table<SessionId, boolean>>
-local keysList = {} ---holds key status for some time after player logs out (Prevents frustration by crashing the client)
+local loggedOutKeys = {} ---holds key status for some time after player logs out (Prevents frustration by crashing the client)
 
 ---@alias LogoutTime integer
 ---@type table<CitizenId, LogoutTime>
-local keysLifetime = {} ---Life timestamp of the keys of a character who has logged out
+local logedOutTime = {} ---Life timestamp of the keys of a character who has logged out
 
 ---Gets Citizen Id based on source
 ---@param source number ID of the player
@@ -24,18 +24,18 @@ RegisterNetEvent('QBCore:Server:OnPlayerLoaded', function()
     local src = source
     local citizenId = getCitizenId(src)
     if not citizenId then return end
-    if keysList[citizenId] then
-        Player(src).state:set('keysList', keysList[citizenId], true)
-        keysList[citizenId] = nil
-        keysLifetime[citizenId] = nil
+    if loggedOutKeys[citizenId] then
+        Player(src).state:set('keysList', loggedOutKeys[citizenId], true)
+        loggedOutKeys[citizenId] = nil
+        logedOutTime[citizenId] = nil
     end
 end)
 
 local function onPlayerUnload(src)
     local citizenId = getCitizenId(src)
     if not citizenId then return end
-    keysList[citizenId] = Player(src).state.keysList
-    keysLifetime[citizenId] = os.time()
+    loggedOutKeys[citizenId] = Player(src).state.keysList
+    logedOutTime[citizenId] = os.time()
 end
 
 RegisterNetEvent('QBCore:Server:OnPlayerUnload', onPlayerUnload)
@@ -48,10 +48,10 @@ end)
 lib.cron.new('*/'..config.runClearCronMinutes ..' * * * *', function ()
     local time = os.time()
     local seconds = config.runClearCronMinutes * 60
-    for citizenId, lifetime in pairs(keysLifetime) do
+    for citizenId, lifetime in pairs(logedOutTime) do
         if lifetime + seconds < time then
-            keysList[citizenId] = nil
-            keysLifetime[citizenId] = nil
+            loggedOutKeys[citizenId] = nil
+            logedOutTime[citizenId] = nil
         end
     end
 end, {debug = debug})
@@ -61,10 +61,11 @@ end, {debug = debug})
 ---@param vehicle number
 function RemoveKeys(source, vehicle)
     local citizenid = getCitizenId(source)
-
     if not citizenid then return end
 
-    local keys = Player(source).state.keysList or {}
+    local keys = Player(source).state.keysList
+    if not keys then return end
+
     local sessionId = Entity(vehicle).state.sessionId
     if not keys[sessionId] then return end
     keys[sessionId] = nil
@@ -97,3 +98,17 @@ function GiveKeys(source, vehicle)
 end
 
 exports('GiveKeys', GiveKeys)
+
+---@param src number
+---@param vehicle number
+---@return boolean?
+function HasKeys(src, vehicle)
+    local keysList = Player(src).state.keysList
+    if not keysList then return end
+
+    local sessionId = Entity(vehicle).state.sessionId
+    return keysList[sessionId]
+end
+
+exports('HasKeys', HasKeys)
+


### PR DESCRIPTION
This PR adds backwards compatibility with qb-vehiclekeys events and exports to Give, Remove, & check if a player has keys to a certain vehicle plate. This is done by searching through the vehicles to find the vehicles with the matching plate and then invoking native qbx_vehiclekeys functions to handle the rest. This means that if multiple vehicles have the same plate, these compatibility functions will operate on all of them. The bridge can be enabled/disabled via convar.

Other misc refactors done as part of this PR to support the bridge:

- made fxmanifest files more specific
- made client HasKeys a global function
- renamed server/keys.lua keysList and keysLifeTime to better reflect their use
- moved server HasKeys to keys.lua
- added some early return conditions in keys.lua