### PR TITLE
refactor(client): use global functions instead of modules

### DIFF
--- a/client/carjack.lua
+++ b/client/carjack.lua
@@ -1,8 +1,5 @@
 local config = require 'config.client'
-local functions = require 'client.functions'
 local sharedFunctions = require 'shared.functions'
-
-local sendPoliceAlertAttempt = functions.sendPoliceAlertAttempt
 
 local getIsCloseToCoords = sharedFunctions.getIsCloseToCoords
 local getIsBlacklistedWeapon = sharedFunctions.getIsBlacklistedWeapon
@@ -103,7 +100,7 @@ local function carjackVehicle(driver, vehicle)
             end
             TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
             Wait(2000)
-            sendPoliceAlertAttempt('carjack')
+            SendPoliceAlertAttempt('carjack')
         end
     else
         makePedFlee(driver)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -1,11 +1,10 @@
 local config = require 'config.client'
 local functions = require 'shared.functions'
-local public = {}
 
 ---Grants keys for job shared vehicles
 ---@param vehicle number The entity number of the vehicle.
 ---@return boolean? `true` if the vehicle is shared for a player's job, `nil` otherwise.
-function public.areKeysJobShared(vehicle)
+function AreKeysJobShared(vehicle)
     local job = QBX.PlayerData.job.name
     local jobInfo = config.sharedKeys[job]
 
@@ -30,47 +29,12 @@ exports('HasKeys', HasKeys)
 ---Checks if player has vehicle keys of or access to the vehicle is provided as part of his job.
 ---@param vehicle number The entity number of the vehicle.
 ---@return boolean? `true` if player has access to the vehicle, `nil` otherwise.
-function public.getIsVehicleAccessible(vehicle)
-    return HasKeys(vehicle) or public.areKeysJobShared(vehicle)
-end
-
-function public.toggleEngine(vehicle)
-    if not public.getIsVehicleAccessible(vehicle) then return end
-    local engineOn = GetIsVehicleEngineRunning(vehicle)
-    SetVehicleEngineOn(vehicle, not engineOn, false, true)
-end
-
-local function getVehicleInDirection(coordFromOffset, coordToOffset)
-    local coordFrom = GetOffsetFromEntityInWorldCoords(cache.ped, coordFromOffset.x, coordFromOffset.y, coordFromOffset.z)
-    local coordTo = GetOffsetFromEntityInWorldCoords(cache.ped, coordToOffset.x, coordToOffset.y, coordToOffset.z)
-    local rayHandle = CastRayPointToPoint(coordFrom.x, coordFrom.y, coordFrom.z, coordTo.x, coordTo.y, coordTo.z, 10, cache.ped, 0)
-    local _, _, _, _, vehicle = GetShapeTestResult(rayHandle)
-    return vehicle
-end
-
--- If in vehicle returns that, otherwise tries 3 different raycasts to get the vehicle they are facing.
--- Raycasts picture: https://i.imgur.com/FRED0kV.png
-function public.getVehicleInFront()
-    if cache.vehicle then
-        return cache.vehicle
-    end
-    local raycastOffsetTable = {
-        { fromOffset = vec3(0.0, 0.0, 0.0), toOffset = vec3(0.0, 20.0, -10.0) }, -- Waist to ground 45 degree angle
-        { fromOffset = vec3(0.0, 0.0, 0.7), toOffset = vec3(0.0, 10.0, -10.0) }, -- Head to ground 30 degree angle
-        { fromOffset = vec3(0.0, 0.0, 0.7), toOffset = vec3(0.0, 10.0, -20.0) }, -- Head to ground 15 degree angle
-    }
-
-    for i = 1, #raycastOffsetTable do
-        local vehicle = getVehicleInDirection(raycastOffsetTable[i]['fromOffset'], raycastOffsetTable[i]['toOffset'])
-
-        if vehicle and DoesEntityExist(vehicle) and IsEntityAVehicle(vehicle) then
-            return vehicle
-        end
-    end
+function GetIsVehicleAccessible(vehicle)
+    return HasKeys(vehicle) or AreKeysJobShared(vehicle)
 end
 
 local alertSend = false --Variable strictly related to sendPoliceAlertAttempt, not used elsewhere
-function public.sendPoliceAlertAttempt(type)
+function SendPoliceAlertAttempt(type)
     if alertSend then return end
     alertSend = true
 
@@ -167,7 +131,7 @@ local function lockpickCallback(vehicle, isAdvancedLockedpick, isSuccess)
     if isSuccess then
         lockpickSuccessCallback(vehicle)
     else -- if player fails quickevent
-        public.sendPoliceAlertAttempt('carjack')
+        SendPoliceAlertAttempt('carjack')
         SetVehicleAlarm(vehicle, false)
         SetVehicleAlarmTimeLeft(vehicle, config.vehicleAlarmDuration)
         TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
@@ -182,7 +146,7 @@ local islockpickingProcessLocked = false -- lock flag
 ---@param isAdvancedLockedpick boolean Determines whether an advanced lockpick was used
 ---@param maxDistance number? The max distance to check.
 ---@param customChallenge boolean? lockpick challenge
-function public.lockpickDoor(isAdvancedLockedpick, maxDistance, customChallenge)
+function LockpickDoor(isAdvancedLockedpick, maxDistance, customChallenge)
     maxDistance = maxDistance or 2
     local pedCoords = GetEntityCoords(cache.ped)
     local vehicle = lib.getClosestVehicle(pedCoords, maxDistance * 2, false) -- The difference between the door and the center of the vehicle
@@ -238,7 +202,7 @@ local function hotwireCallback(vehicle, isAdvancedLockedpick, isSuccess)
     if isSuccess then
         hotwireSuccessCallback(vehicle)
     else -- if player fails quickevent
-        public.sendPoliceAlertAttempt('carjack')
+        SendPoliceAlertAttempt('carjack')
         TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
         exports.qbx_core:Notify(locale('notify.failed_lockedpick'), 'error')
     end
@@ -251,8 +215,8 @@ local isHotwiringProcessLocked = false -- lock flag
 ---@param vehicle number The entity number of the vehicle.
 ---@param isAdvancedLockedpick boolean Determines whether an advanced lockpick was used
 ---@param customChallenge boolean? lockpick challenge
-function public.hotwire(vehicle, isAdvancedLockedpick, customChallenge)
-    if cache.seat ~= -1 or public.getIsVehicleAccessible(vehicle) then return end
+function Hotwire(vehicle, isAdvancedLockedpick, customChallenge)
+    if cache.seat ~= -1 or GetIsVehicleAccessible(vehicle) then return end
     local skillCheckConfig = config.skillCheck[isAdvancedLockedpick and 'advancedHotwire' or 'hotwire']
 
     skillCheckConfig = skillCheckConfig.model[GetEntityModel(vehicle)]
@@ -275,5 +239,3 @@ function public.hotwire(vehicle, isAdvancedLockedpick, customChallenge)
         isHotwiringProcessLocked = false -- end of the critical section
     end)
 end
-
-return public

--- a/client/main.lua
+++ b/client/main.lua
@@ -3,15 +3,7 @@
 -----------------------
 
 local config = require 'config.client'
-local functions = require 'client.functions'
 local sharedFunctions = require 'shared.functions'
-
-local hotwire = functions.hotwire
-local toggleEngine = functions.toggleEngine
-local lockpickDoor = functions.lockpickDoor
-local areKeysJobShared = functions.areKeysJobShared
-local sendPoliceAlertAttempt = functions.sendPoliceAlertAttempt
-local getIsVehicleAccessible = functions.getIsVehicleAccessible
 
 local getIsVehicleShared = sharedFunctions.getIsVehicleShared
 local getIsVehicleAlwaysUnlocked = sharedFunctions.getIsVehicleAlwaysUnlocked
@@ -27,7 +19,7 @@ local getIsVehicleCarjackingImmune = sharedFunctions.getIsVehicleCarjackingImmun
 ---@param anim any Aniation
 local function setVehicleDoorLock(vehicle, state, anim)
     if not vehicle or getIsVehicleAlwaysUnlocked(vehicle) or getIsVehicleShared(vehicle) then return end
-    if getIsVehicleAccessible(vehicle) then
+    if GetIsVehicleAccessible(vehicle) then
 
         if anim then
             lib.playAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3.0, 3.0, -1, 49)
@@ -110,7 +102,7 @@ local function onEnteringDriverSeat()
     local vehicle = cache.vehicle
     if getIsVehicleShared(vehicle) then return end
 
-    local isVehicleAccessible = getIsVehicleAccessible(vehicle)
+    local isVehicleAccessible = GetIsVehicleAccessible(vehicle)
     if isVehicleAccessible then return end
 
     local isVehicleRunning = GetIsVehicleEngineRunning(vehicle)
@@ -127,7 +119,7 @@ local function onEnteringDriverSeat()
             SetVehicleEngineOn(vehicle, false, true, true)
             DisableControlAction(0, 71, true)
             Wait(0)
-            isVehicleAccessible = getIsVehicleAccessible(vehicle)
+            isVehicleAccessible = GetIsVehicleAccessible(vehicle)
         end
         if lib.progressActive() then
             lib.cancelProgress()
@@ -164,6 +156,12 @@ togglelocksBind = lib.addKeybind({
     end
 })
 
+local function toggleEngine(vehicle)
+    if not GetIsVehicleAccessible(vehicle) then return end
+    local engineOn = GetIsVehicleEngineRunning(vehicle)
+    SetVehicleEngineOn(vehicle, not engineOn, false, true)
+end
+
 local engineBind
 engineBind = lib.addKeybind({
     name = 'toggleengine',
@@ -191,10 +189,10 @@ lib.addKeybind({
             setSearchLabelState(false)
             local vehicle = cache.vehicle
             local isFound
-            if not getIsVehicleAccessible(vehicle) then
+            if not GetIsVehicleAccessible(vehicle) then
                 isFound = findKeys(GetEntityModel(vehicle), GetVehicleClass(vehicle), vehicle)
                 SetTimeout(10000, function()
-                    sendPoliceAlertAttempt('steal')
+                    SendPoliceAlertAttempt('steal')
                 end)
             end
             Wait(config.timeBetweenHotwires)
@@ -239,11 +237,11 @@ RegisterNetEvent('lockpicks:UseLockpick', function(isAdvanced)
     if vehicle then
         if isSearchAllowed then
             setSearchLabelState(false)
-            hotwire(vehicle, isAdvanced)
+            Hotwire(vehicle, isAdvanced)
             setSearchLabelState(true)
         end
     else
-        lockpickDoor(isAdvanced)
+        LockpickDoor(isAdvanced)
     end
 end)
 
@@ -258,7 +256,7 @@ for _, info in pairs(config.sharedKeys) do
         lib.onCache('vehicle', function (vehicle)
             local leftVehicle = cache.vehicle
             if not vehicle and leftVehicle then
-                local isShared = areKeysJobShared(leftVehicle)
+                local isShared = AreKeysJobShared(leftVehicle)
                 local isAutolockEnabled = config.sharedKeys[QBX.PlayerData.job.name]?.enableAutolock
 
                 if isShared and isAutolockEnabled then

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -16,6 +16,7 @@ shared_scripts {
 
 client_scripts {
     '@qbx_core/modules/playerdata.lua',
+    'client/functions.lua',
     'client/main.lua',
     'client/carjack.lua',
     'bridge/qb/client.lua',
@@ -31,7 +32,6 @@ server_scripts {
 }
 
 files {
-    'client/functions.lua',
     'shared/functions.lua',
     'locales/*.json',
     'config/client.lua',


### PR DESCRIPTION
This makes it easier to refactor and split off feature based files. functions.lua is too broad and became a dumping ground.

Also deleted raycasting, which was not being used.