### PR TITLE
feat: give vehicle owner keys

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -21,9 +21,21 @@ end
 function HasKeys(vehicle)
     vehicle = vehicle or cache.vehicle
     if not vehicle then return false end
-    local keysList = LocalPlayer.state.keysList or {}
-    local sessionId = Entity(vehicle).state.sessionId
-    return keysList[sessionId] or false
+    local keysList = LocalPlayer.state.keysList
+    if keysList then
+        local sessionId = Entity(vehicle).state.sessionId
+        if keysList[sessionId] then
+            return true
+        end
+    end
+
+    local owner = Entity(vehicle).state.owner
+    if owner and QBX.PlayerData.citizenid == owner then
+        lib.callback.await('qbx_vehiclekeys:server:giveKeys', false, VehToNet(vehicle))
+        return true
+    end
+
+    return false
 end
 
 exports('HasKeys', HasKeys)


### PR DESCRIPTION
Fixes #139 

Sets a new statebag on owned vehicles for the owner's citizenid. Uses this to give the owner keys if they don't have them in an access on demand fashion. (When HasKeys is checked, give keys to the owner if they don't already have them)