### PR TITLE
fix: vehicle becoming permanently locked

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -25,6 +25,12 @@ local function setVehicleDoorLock(vehicle, state, anim)
             lib.playAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3.0, 3.0, -1, 49)
         end
 
+        --- if the statebag is out of sync, rely on it as the source of truth and sync the client to the statebag's value
+        local stateBagValue = Entity(vehicle).state.doorslockstate
+        if GetVehicleDoorLockStatus(vehicle) ~= stateBagValue then
+            SetVehicleDoorsLocked(vehicle, stateBagValue)
+        end
+
         local lockstate = state ~= nil
             and (state and 2 or 1)
             or (GetVehicleDoorLockStatus(vehicle) % 2) + 1 -- use ternary


### PR DESCRIPTION
Was able to reproduce a state where the statebag value would not match the client's setting for the vehicle lock state by having two clients both unlocking/locking the same vehicle at the same time. This resulted in a deadlock, where the native state was locked, but the statebag was set to locked, so the client attempted to toggle the state to locked. Since the state was already locked, this resulted in a no-op and the vehicle could not be unlocked.

This PR fixes this issue by checking on the client if the statebag is out of sync with the native and correcting the client to be set to the statebag before doing toggle logic. This is done when the client toggles the locks of the vehicle.