### PR TITLE
fix: notify spam

### DIFF
--- a/bridge/qb/server.lua
+++ b/bridge/qb/server.lua
@@ -4,7 +4,10 @@ local function giveKeys(source, plate)
     local vehicles = plate and GetVehiclesFromPlate(plate) or {GetVehiclePedIsIn(GetPlayerPed(source), false)}
     local success = nil
     for i = 1, #vehicles do
-        success = success or GiveKeys(source, vehicles[i])
+        success = success or GiveKeys(source, vehicles[i], true)
+    end
+    if success then
+        exports.qbx_core:Notify(source, locale('notify.keys_taken'))
     end
     return success
 end
@@ -14,8 +17,9 @@ CreateQbExport('GiveKeys', giveKeys)
 local function removeKeys(source, plate)
     local vehicles = GetVehiclesFromPlate(plate)
     for i = 1, #vehicles do
-        RemoveKeys(source, vehicles[i])
+        RemoveKeys(source, vehicles[i], true)
     end
+    exports.qbx_core:Notify(source, locale('notify.keys_removed'))
 end
 
 CreateQbExport('RemoveKeys', removeKeys)

--- a/bridge/qb/server.lua
+++ b/bridge/qb/server.lua
@@ -2,9 +2,11 @@ if GetConvar('qbx_vehiclekeys:enableBridge', 'true') ~= 'true' then return end
 
 local function giveKeys(source, plate)
     local vehicles = plate and GetVehiclesFromPlate(plate) or {GetVehiclePedIsIn(GetPlayerPed(source), false)}
-    local success = nil
+    local success = false
     for i = 1, #vehicles do
-        success = success or GiveKeys(source, vehicles[i], true)
+        if GiveKeys(source, vehicles[i], true) then
+            success = true
+        end
     end
     if success then
         exports.qbx_core:Notify(source, locale('notify.keys_taken'))
@@ -16,10 +18,16 @@ CreateQbExport('GiveKeys', giveKeys)
 
 local function removeKeys(source, plate)
     local vehicles = GetVehiclesFromPlate(plate)
+    local success = false
     for i = 1, #vehicles do
-        RemoveKeys(source, vehicles[i], true)
+        if RemoveKeys(source, vehicles[i], true) then
+            success = true
+        end
     end
-    exports.qbx_core:Notify(source, locale('notify.keys_removed'))
+    if success then
+        exports.qbx_core:Notify(source, locale('notify.keys_removed'))
+    end
+    return success
 end
 
 CreateQbExport('RemoveKeys', removeKeys)

--- a/server/keys.lua
+++ b/server/keys.lua
@@ -59,7 +59,8 @@ end, {debug = debug})
 --- Removing the vehicle keys from the user
 ---@param source number ID of the player
 ---@param vehicle number
-function RemoveKeys(source, vehicle)
+---@param skipNotification? boolean
+function RemoveKeys(source, vehicle, skipNotification)
     local citizenid = getCitizenId(source)
     if not citizenid then return end
 
@@ -73,7 +74,9 @@ function RemoveKeys(source, vehicle)
     Player(source).state:set('keysList', keys, true)
 
     TriggerClientEvent('qbx_vehiclekeys:client:OnLostKeys', source)
-    exports.qbx_core:Notify(source, locale('notify.keys_removed'))
+    if not skipNotification then
+        exports.qbx_core:Notify(source, locale('notify.keys_removed'))
+    end
 
     return true
 end
@@ -82,7 +85,8 @@ exports('RemoveKeys', RemoveKeys)
 
 ---@param source number
 ---@param vehicle number
-function GiveKeys(source, vehicle)
+---@param skipNotification? boolean
+function GiveKeys(source, vehicle, skipNotification)
     local citizenid = getCitizenId(source)
     if not citizenid then return end
 
@@ -93,7 +97,9 @@ function GiveKeys(source, vehicle)
     keys[sessionId] = true
 
     Player(source).state:set('keysList', keys, true)
-    exports.qbx_core:Notify(source, locale('notify.keys_taken'))
+    if not skipNotification then
+        exports.qbx_core:Notify(source, locale('notify.keys_taken'))
+    end
     return true
 end
 


### PR DESCRIPTION
When giving keys via the bridge (by plate) many vehicles match to the plate, so many keys are given and the notifications per vehicle spam the player. This changes the bridge to only show one notification even if keys are given to many vehicles.

- Adds a skipNotification optional field to RemoveKeys and GiveKeys
- Bridge handles its own notifications