### PR TITLE
fix: flip ternary

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -73,7 +73,7 @@ AddEventHandler('entityCreated', function (entity)
     local isPed = type == EntityType.Ped
     local isVehicle = type == EntityType.Vehicle
     if not isPed and not isVehicle then return end
-    local vehicle = isPed and GetVehiclePedIsIn(entity, false) or entity
+    local vehicle = not isPed and entity or GetVehiclePedIsIn(entity, false)
 
     if not DoesEntityExist(vehicle) then return end -- ped can be not in vehicle, so we need to check if vehicle is a entity, otherwise it will return 0
 


### PR DESCRIPTION
## Description
GetVehiclePedIsIn can be 0 and we can get ped type entity instead

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
