### PR TITLE
feat: on demand vehicle lock init

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -261,14 +261,28 @@ local function onVehicleAttemptToEnter(vehicle)
     TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(vehicle), lockState)
 end
 
-CreateThread(function()
-    while true do
-        if LocalPlayer.state.isLoggedIn then
+local isLoggedIn = false
+
+local function playerEnterVehLoop()
+    CreateThread(function()
+        while isLoggedIn do
             local vehicle = GetVehiclePedIsTryingToEnter(cache.ped)
             if vehicle ~= 0 then
                 onVehicleAttemptToEnter(vehicle)
             end
+            Wait(100)
         end
-        Wait(100)
+    end)
+end
+
+CreateThread(function()
+    if LocalPlayer.state.isLoggedIn then
+        playerEnterVehLoop()
     end
+end)
+
+AddStateBagChangeHandler('isLoggedIn', ('player:%s'):format(cache.serverId), function(_, _, value)
+    isLoggedIn = value
+    if not value then return end
+    playerEnterVehLoop()
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -59,25 +59,3 @@ RegisterNetEvent('qb-vehiclekeys:server:setVehLockState', function(vehNetId, sta
     if getIsVehicleAlwaysUnlocked(vehicleEntity) or getIsVehicleShared(vehicleEntity) then return end
     Entity(vehicleEntity).state:set('doorslockstate', state, true)
 end)
-
----Lock every spawned vehicle
----@param entity number The entity number of the vehicle.
-AddEventHandler('entityCreated', function (entity)
-    if not entity
-        or type(entity) ~= 'number'
-        or not DoesEntityExist(entity)
-        or GetEntityPopulationType(entity) > 5
-    then return end
-
-    local type = GetEntityType(entity)
-    local isPed = type == EntityType.Ped
-    local isVehicle = type == EntityType.Vehicle
-    if not isPed and not isVehicle then return end
-    local vehicle = isPed and GetVehiclePedIsIn(entity, false) or entity
-
-    if not DoesEntityExist(vehicle) then return end -- ped can be not in vehicle, so we need to check if vehicle is a entity, otherwise it will return 0
-
-    local isLocked = not getIsVehicleAlwaysUnlocked(vehicle)
-        and getIsVehicleInitiallyLocked(vehicle, isPed)
-    SetVehicleDoorsLocked(vehicle, isLocked and 2 or 1)
-end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,16 +2,7 @@ local config = require 'config.server'
 local sharedFunctions = require 'shared.functions'
 
 local getIsVehicleAlwaysUnlocked = sharedFunctions.getIsVehicleAlwaysUnlocked
-local getIsVehicleInitiallyLocked = sharedFunctions.getIsVehicleInitiallyLocked
 local getIsVehicleShared = sharedFunctions.getIsVehicleShared
-
----@enum EntityType
-local EntityType = {
-    NoEntity = 0,
-    Ped = 1,
-    Vehicle = 2,
-    Object = 3
-}
 
 lib.callback.register('qbx_vehiclekeys:server:findKeys', function(source, netId)
     local vehicle = NetworkGetEntityFromNetworkId(netId)


### PR DESCRIPTION
Instead of initializing vehicle lock state using entityCreated server event, which has a high performance cost, this PR determines the vehicle lock state of NPC vehicles on demand. Clients listen every 100ms for an attempt to enter a vehicle, randomize its lock state based on the config, and then set the state bag so that lock state is synced to other players.