### PR TITLE
Add secondary check for hasKeys

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -28,6 +28,10 @@ function HasKeys(vehicle)
     end
 
     local owner = Entity(vehicle).state.owner
+    if not owner then
+        local hasKey = lib.callback.await('qbx_vehiclekeys:server:hasKeys', false, VehToNet(vehicle))
+        if hasKey then return true else return false end
+    end
     if owner and QBX.PlayerData.citizenid == owner then
         lib.callback.await('qbx_vehiclekeys:server:giveKeys', false, VehToNet(vehicle))
         return true

--- a/server/keys.lua
+++ b/server/keys.lua
@@ -118,6 +118,20 @@ function HasKeys(src, vehicle)
     end
 
     local owner = Entity(vehicle).state.owner
+    if not owner then
+        local plate = qbx.getVehiclePlate(vehicle)
+        local vehicleId = exports.qbx_vehicles:GetVehicleIdByPlate(plate)
+        if vehicleId then
+            owner = exports.qbx_vehicles:GetPlayerVehicle(vehicleId)?.citizenid
+            if owner then
+                Entity(vehicle).state:set('owner', owner, true)
+            else
+                return false
+            end
+        else
+            return false
+        end
+    end
     if owner and getCitizenId(src) == owner then
         GiveKeys(src, vehicle)
         return true
@@ -130,6 +144,10 @@ exports('HasKeys', HasKeys)
 
 lib.callback.register('qbx_vehiclekeys:server:giveKeys', function(source, netId)
     GiveKeys(source, NetworkGetEntityFromNetworkId(netId))
+end)
+
+lib.callback.register('qbx_vehiclekeys:server:hasKeys', function(source, netId)
+    return HasKeys(source, NetworkGetEntityFromNetworkId(netId))
 end)
 
 AddStateBagChangeHandler('vehicleid', '', function(bagName, _, vehicleId)


### PR DESCRIPTION
## Description

This PR improves the verification logic for hasKeys to ensure that vehicle owners can still access their vehicles after a server restart. When Entity(vehicle).state.owner is found to be empty (for example, following a vehicle regeneration by another plugin), the system now performs an additional check against the database to confirm if the player has access to the vehicle keys.

#154 

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
