### PR TITLE
fix(bridge): statebag spam

### DIFF
--- a/bridge/qb/server.lua
+++ b/bridge/qb/server.lua
@@ -7,6 +7,7 @@ local function giveKeys(source, plate)
         if GiveKeys(source, vehicles[i], true) then
             success = true
         end
+        Wait(20)
     end
     if success then
         exports.qbx_core:Notify(source, locale('notify.keys_taken'))
@@ -23,6 +24,7 @@ local function removeKeys(source, plate)
         if RemoveKeys(source, vehicles[i], true) then
             success = true
         end
+        Wait(20)
     end
     if success then
         exports.qbx_core:Notify(source, locale('notify.keys_removed'))

--- a/bridge/qb/server.lua
+++ b/bridge/qb/server.lua
@@ -4,10 +4,13 @@ local function giveKeys(source, plate)
     local vehicles = plate and GetVehiclesFromPlate(plate) or {GetVehiclePedIsIn(GetPlayerPed(source), false)}
     local success = false
     for i = 1, #vehicles do
-        if GiveKeys(source, vehicles[i], true) then
-            success = true
+        local vehicle = vehicles[i]
+        if DoesEntityExist(vehicle) then
+            if GiveKeys(source, vehicles[i], true) then
+                success = true
+            end
+            Wait(20)
         end
-        Wait(20)
     end
     if success then
         exports.qbx_core:Notify(source, locale('notify.keys_taken'))
@@ -21,10 +24,13 @@ local function removeKeys(source, plate)
     local vehicles = GetVehiclesFromPlate(plate)
     local success = false
     for i = 1, #vehicles do
-        if RemoveKeys(source, vehicles[i], true) then
-            success = true
+        local vehicle = vehicles[i]
+        if DoesEntityExist(vehicle) then
+            if RemoveKeys(source, vehicle, true) then
+                success = true
+            end
+            Wait(20)
         end
-        Wait(20)
     end
     if success then
         exports.qbx_core:Notify(source, locale('notify.keys_removed'))


### PR DESCRIPTION
In qbx_vehiclekeys, we assign keys to a specific vehicle entity rather than a plate. When using native qbx_vehiclekeys exports, the caller passes the entity to assign keys to. However, if using the bridge, we look up all vehicles with the given plate, which normally matches to like 30 vehicles, so it causes heavy performance usage setting statebag on all of those.

This PR fixes the issue by adding a 20ms delay between state bag sets to avoid overload.
