### PR TITLE
fix: Resolve an error when giving keys without ID

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -1,5 +1,6 @@
 return {
     runClearCronMinutes = 5,
+    distanceToHandKeys = 3,
     ---@type table<WeaponTypeGroup, number>
     carjackChance = {                    -- Probability of successful carjacking based on weapon used
         [WeaponTypeGroup.MELEE] = 0.0,

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -1,14 +1,17 @@
+local config = require 'config.server'
+
 ---@param src number
 ---@return number?
 local function getClosestPlayer(src)
     local playerCoords = GetEntityCoords(GetPlayerPed(src))
-    local nearbyPlayers = lib.getNearbyPlayers(playerCoords, 3)
-    local closestPlayer, closestDistance
+    local nearbyPlayers = lib.getNearbyPlayers(playerCoords, config.distanceToHandKeys)
+    local closestPlayer
+    local closestDistance = config.distanceToHandKeys
     for i = 1, #nearbyPlayers do
         local nearbyPlayer = nearbyPlayers[i]
-        if nearbyPlayer.id ~= source then
+        if nearbyPlayer.id ~= src then
             local distance = #(nearbyPlayer.coords - playerCoords)
-            if not distance or distance < closestDistance then
+            if not distance or distance <= closestDistance then
                 closestPlayer = nearbyPlayer
                 closestDistance = distance
             end
@@ -48,6 +51,9 @@ local function transferKeys(source, target, enforceSrcHasKeys)
         local closestPlayer = getClosestPlayer(source)
         if closestPlayer then
             GiveKeys(closestPlayer, vehicle)
+            exports.qbx_core:Notify(source, locale('notify.gave_keys'))
+        else
+            exports.qbx_core:Notify(source, locale('notify.not_near'), 'error')
         end
     end
 end


### PR DESCRIPTION
## Description
When attempting to hand keys to someone standing next to you without using an ID an error would be generated: 
![image](https://github.com/user-attachments/assets/6cb12194-93a8-4f55-80df-67ec884ee372)

The error was from a nil value. I added a config setting, got rid of the nil value error, and added in user notifications.


Before: https://medal.tv/games/gta-v/clips/je2GVr3kBS0OLfjWB?invite=cr-MSxsZ3csMTk1NzEzNDc0LA
After: https://medal.tv/games/gta-v/clips/je2JXUH9ehD7sHQ5P?invite=cr-MSxPYUMsMTk1NzEzNDc0LA

## Checklist


- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
