### PR TITLE
fix: preventing carjack on scripted entities

### DIFF
--- a/client/carjack.lua
+++ b/client/carjack.lua
@@ -125,13 +125,16 @@ local function watchCarjackingAttempts()
                 and not IsEntityDead(target)
                 and not IsPedAPlayer(target)
             then
-                local targetveh = GetVehiclePedIsIn(target, false)
+                local script = GetEntityScript(target)
+                if not script then
+                    local targetveh = GetVehiclePedIsIn(target, false)
 
-                if GetPedInVehicleSeat(targetveh, -1) == target
-                    and not GetVehicleConfig(targetveh).carjackingImmune
-                    and #(GetEntityCoords(cache.ped) - GetEntityCoords(target)) < 5.0
-                then
-                    carjackVehicle(target, targetveh)
+                    if GetPedInVehicleSeat(targetveh, -1) == target
+                        and not GetVehicleConfig(targetveh).carjackingImmune
+                        and #(GetEntityCoords(cache.ped) - GetEntityCoords(target)) < 5.0
+                    then
+                        carjackVehicle(target, targetveh)
+                    end
                 end
             end
             Wait(100)


### PR DESCRIPTION
## Description
The current carjack code prevents killing the driver in bank trucks, carjack works as soon as the gun is pointed, it needs to be blocked in entities generated by any script.
<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
