### PR TITLE
Update GetVehiclesFromPlate in qb bridge to use CVehicles.

### DIFF
--- a/bridge/qb/shared.lua
+++ b/bridge/qb/shared.lua
@@ -8,14 +8,12 @@ end
 
 function GetVehiclesFromPlate(plate)
     Wait(500) -- delay needed to give client spawned vehicles time to be known to the server
-    local vehicles = GetAllVehicles()
+    local vehicles = GetGamePool('CVehicle')
     local vehEntityFromPlate = {}
 
     for i = 1, #vehicles do
-        local vehicle = vehicles[i]
-        local vehPlate = qbx.getVehiclePlate(vehicle)
-        if plate == vehPlate or GetVehicleNumberPlateText(vehicle) then
-            vehEntityFromPlate[#vehEntityFromPlate + 1] = vehicle
+        if plate == qbx.getVehiclePlate(vehicles[i]) or GetVehicleNumberPlateText(vehicles[i]) then
+            vehEntityFromPlate[#vehEntityFromPlate + 1] = vehicles[i]
         end
     end
 


### PR DESCRIPTION
## Description

This Pull Request fixes an issue with the client version of the GetAllVehicles() that makes client have 2 outcomes,
Its not simplified to only collect the vehicles with the GetGamePool('CVehicle') for faster reads. Also compacted the code to not make useless variables.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
