### PR TITLE
Obtain keys when ped is driving.

### DIFF
--- a/config/client.lua
+++ b/config/client.lua
@@ -27,6 +27,7 @@ return {
     vehicleMaximumLockingDistance = 5.0, -- Minimum distance for vehicle locking
     getKeysWhenEngineIsRunning = true, -- when enabled, gives keys to a player who doesn't have them if they enter the driver seat when the engine is running
     keepEngineOnWhenAbandoned = true, -- when enabled, keeps a vehicle's engine running after exiting
+    getKeysWhenPedIsDriving = true, -- when enabled, gives keys to a player who doesn't have them if they enter the driver seat while a ped is driving.
 
     -- Carjack Settings
     carjackEnable = true,                -- Enables the ability to carjack pedestrian vehicles, stealing them by pointing a weapon at them

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -47,6 +47,7 @@
   "progress": {
     "attempting_carjack": "Pokus o krádež auta...",
     "searching_keys": "Hledání klíčů od auta...",
-    "takekeys": "Odebírání klíčů z těla..."
+    "takekeys": "Odebírání klíčů z těla...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -49,6 +49,7 @@
   "progress": {
     "attempting_carjack": "Forsøger at kapre køretøjet...",
     "searching_keys": "Leder efter bilnøgler...",
-    "takekeys": "Tager nøgler fra kroppen..."
+    "takekeys": "Tager nøgler fra kroppen...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -47,6 +47,7 @@
   "progress": {
     "attempting_carjack": "Versuche, das Auto zu stehlen...",
     "searching_keys": "Suche nach Fahrzeugschlüsseln...",
-    "takekeys": "Fahrzeugschlüssel entnehmen..."
+    "takekeys": "Fahrzeugschlüssel entnehmen...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -49,6 +49,7 @@
   "progress": {
     "attempting_carjack": "Attempting Carjacking...",
     "searching_keys": "Searching for the car keys...",
-    "takekeys": "Taking keys from body..."
+    "takekeys": "Taking keys from body...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -47,6 +47,7 @@
   "progress": {
     "attempting_carjack": "Intentando robar carro...",
     "searching_keys": "Buscando las llaves del carro...",
-    "takekeys": "Obteniendo las llaves del cuerpo..."
+    "takekeys": "Obteniendo las llaves del cuerpo...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/et.json
+++ b/locales/et.json
@@ -47,6 +47,7 @@
   "progress": {
     "attempting_carjack": "Autovarguse katse...",
     "searching_keys": "Autovõtmete otsimine...",
-    "takekeys": "Võtmete kehast võtmine..."
+    "takekeys": "Võtmete kehast võtmine...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -47,6 +47,7 @@
   "progress": {
     "attempting_carjack": "Tentative de vol de carjack..",
     "searching_keys": "Cherche les clés du véhicule..",
-    "takekeys": "Prend les clés du corps.."
+    "takekeys": "Prend les clés du corps..",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -47,6 +47,7 @@
   "progress": {
     "attempting_carjack": "カージャックを試みています...",
     "searching_keys": "車の鍵を探しています...",
-    "takekeys": "鍵を盗んでいます..."
+    "takekeys": "鍵を盗んでいます...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -47,6 +47,7 @@
   "progress": {
     "attempting_carjack": "Voertuig Stelen...",
     "searching_keys": "Sleutels Zoeken...",
-    "takekeys": "Sleutels van lichaam af halen..."
+    "takekeys": "Sleutels van lichaam af halen...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/pt-br.json
+++ b/locales/pt-br.json
@@ -49,7 +49,8 @@
   "progress": {
     "attempting_carjack": "Tentando roubar o carro...",
     "searching_keys": "Procurando as chaves do carro...",
-    "takekeys": "Pegando chaves do corpo..."
+    "takekeys": "Pegando chaves do corpo...",
+    "rob_keys": "Taking drivers keys..."
   }
 }
   

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -47,6 +47,7 @@
   "progress": {
     "attempting_carjack": "Tentativa de assalto ao veículo...",
     "searching_keys": "A procurar pelas chaves do carro...",
-    "takekeys": "A tirar as chaves do corpo..."
+    "takekeys": "A tirar as chaves do corpo...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -49,6 +49,7 @@
   "progress": {
     "attempting_carjack": "Ameninți șoferul...",
     "searching_keys": "Cauți cheile vehiculului...",
-    "takekeys": "Iei cheile de la corp..."
+    "takekeys": "Iei cheile de la corp...",
+    "rob_keys": "Taking drivers keys..."
   }
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -47,6 +47,7 @@
   "progress": {
     "attempting_carjack": "Araç hırsızlığı deneniyor...",
     "searching_keys": "Araç anahtarları aranıyor...",
-    "takekeys": "Cesetten anahtarlar alınıyor..."
+    "takekeys": "Cesetten anahtarlar alınıyor...",
+    "rob_keys": "Taking drivers keys..."
   }
 }


### PR DESCRIPTION
## Description
Feature added for if a ped is driving and you yank them out it will give you the keys rather than having to search for them.

locales have just the variable (needs translations)


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
