### PR TITLE
feat(client/main): add vehicle engine keep-alive functionality when abandoned

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -87,6 +87,10 @@ lib.onCache('seat', function(newSeat)
     onEnteringDriverSeat()
 end)
 
+lib.onCache('vehicle', function(vehicle)
+    SetVehicleKeepEngineOnWhenAbandoned(vehicle, config.keepEngineOnWhenAbandoned)
+end)
+
 -----------------------
 ------ Key Binds ------
 -----------------------

--- a/client/main.lua
+++ b/client/main.lua
@@ -88,6 +88,7 @@ lib.onCache('seat', function(newSeat)
 end)
 
 lib.onCache('vehicle', function(vehicle)
+    if not vehicle then return end
     SetVehicleKeepEngineOnWhenAbandoned(vehicle, config.keepEngineOnWhenAbandoned)
 end)
 


### PR DESCRIPTION
## Description

Adds a feature to keep the vehicle engine running when it's abandoned. This ensures that the engine stays on based on the `keepEngineOnWhenAbandoned` setting in the configuration.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
