### PR TITLE
fix: resolve invalid plate checking condition

### DIFF
--- a/bridge/qb/shared.lua
+++ b/bridge/qb/shared.lua
@@ -14,7 +14,7 @@ function GetVehiclesFromPlate(plate)
     for i = 1, #vehicles do
         local vehicle = vehicles[i]
         local vehPlate = qbx.getVehiclePlate(vehicle)
-        if plate == vehPlate or GetVehicleNumberPlateText(vehicle) then
+        if plate == (vehPlate or GetVehicleNumberPlateText(vehicle)) then
             vehEntityFromPlate[#vehEntityFromPlate + 1] = vehicle
         end
     end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

I fixed an issue where using 'givekeys' granted a player access to all nearby vehicles, along with other features that check vehicles by plate, by correcting the if condition.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
