### PR TITLE
Keyfob prop

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,5 +1,48 @@
 local config = require 'config.client'
 
+---Creates a prop attached to a ped's bone (right hand)
+---@param ped number The ped entity to attach the prop to
+---@param modelName string The model name of the prop to create
+---@param boneId number The bone ID to attach the prop to
+---@param coords vector3 The position offset from the bone
+---@param rotation vector3 The rotation offset from the bone
+---@return number|nil prop The created prop entity, or nil if it failed
+local function createPropOnBone(ped, modelName, boneId, coords, rotation)
+    local model = joaat(modelName)
+    local loaded = lib.waitFor(function()
+        RequestModel(model)
+        if HasModelLoaded(model) then return true end
+    end, 5000) -- 5 second timeout, returns nil if it fails
+
+    if not loaded then
+        warn(('Failed to load keyfob model: %s'):format(modelName))
+        return nil
+    end
+
+    local prop = CreateObject(model, 0, 0, 0, true, true, false)
+    lib.waitFor(function()
+        if DoesEntityExist(prop) then return true end
+    end, 5000)
+
+    if not DoesEntityExist(prop) then
+        warn(('Failed to create object for model: %s'):format(modelName))
+        SetModelAsNoLongerNeeded(model)
+        return nil
+    end
+
+    AttachEntityToEntity(
+        prop,
+        ped,
+        GetPedBoneIndex(ped, boneId),
+        coords.x, coords.y, coords.z,
+        rotation.x, rotation.y, rotation.z,
+        true, true, false, true, 1, true
+    )
+
+    SetModelAsNoLongerNeeded(model)
+    return prop
+end
+
 ---client uses key fob to toggle the door locks
 ---@param vehicle number The entity number of the vehicle.
 local function toggleLock(vehicle)
@@ -7,21 +50,16 @@ local function toggleLock(vehicle)
     local vehicleConfig = GetVehicleConfig(vehicle)
     if vehicleConfig.noLock or vehicleConfig.shared then return end
     if GetIsVehicleAccessible(vehicle) then
-
-        local propModel = joaat('m23_2_prop_m32_carkey_fob_01a')
-        RequestModel(propModel)
-        while not HasModelLoaded(propModel) do Wait(0) end
-
-        local prop = CreateObject(propModel, 0, 0, 0, true, true, false)
-        while not DoesEntityExist(prop) do Wait(0) end
-
-        AttachEntityToEntity(
-            prop, cache.ped,
-            GetPedBoneIndex(cache.ped, 57005), 0.12, 0.04, 0.0, 27.42, 180.8, 176.34, true, true, false, true, 1, true)
+        local prop = createPropOnBone(
+            cache.ped,
+            'm23_2_prop_m32_carkey_fob_01a', -- prop model
+            57005, -- player bone
+            vector3(0.12, 0.04, 0.0), -- coords
+            vector3(27.42, 180.8, 176.34) -- rotation
+        )
 
         lib.playAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3.0, 3.0, -1, 49)
-		
-		--- if the statebag is out of sync, rely on it as the source of truth and sync the client to the statebag's value
+
         local stateBagValue = Entity(vehicle).state.doorslockstate
         if GetVehicleDoorLockStatus(vehicle) ~= stateBagValue then
             SetVehicleDoorsLocked(vehicle, stateBagValue)
@@ -36,10 +74,19 @@ local function toggleLock(vehicle)
         Wait(200)
         SetVehicleLights(vehicle, 0)
         Wait(300)
+
+        -- Wait for the animation to fully finish before cleaning up the prop
+        lib.waitFor(function()
+            if not IsEntityPlayingAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3) then
+                return true
+            end
+        end, 3000)
+
         ClearPedTasks(cache.ped)
 
-        DeleteObject(prop)
-        SetModelAsNoLongerNeeded(propModel)
+        if prop then
+            DeleteObject(prop)
+        end
     else
         exports.qbx_core:Notify(locale('notify.no_keys'), 'error')
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -52,14 +52,12 @@ local function toggleLock(vehicle)
     if GetIsVehicleAccessible(vehicle) then
         local prop = createPropOnBone(
             cache.ped,
-            'm23_2_prop_m32_carkey_fob_01a', -- prop model
-            57005, -- player bone
-            vector3(0.12, 0.04, 0.0), -- coords
-            vector3(27.42, 180.8, 176.34) -- rotation
+            'm23_2_prop_m32_carkey_fob_01a',
+            57005,
+            vector3(0.12, 0.04, 0.0),
+            vector3(27.42, 180.8, 176.34)
         )
-
         lib.playAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3.0, 3.0, -1, 49)
-
         local stateBagValue = Entity(vehicle).state.doorslockstate
         if GetVehicleDoorLockStatus(vehicle) ~= stateBagValue then
             SetVehicleDoorsLocked(vehicle, stateBagValue)
@@ -74,16 +72,7 @@ local function toggleLock(vehicle)
         Wait(200)
         SetVehicleLights(vehicle, 0)
         Wait(300)
-
-        -- Wait for the animation to fully finish before cleaning up the prop
-        lib.waitFor(function()
-            if not IsEntityPlayingAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3) then
-                return true
-            end
-        end, 3000)
-
         ClearPedTasks(cache.ped)
-
         if prop then
             DeleteObject(prop)
         end

--- a/client/main.lua
+++ b/client/main.lua
@@ -9,6 +9,12 @@ local config = require 'config.client'
 ---@return number|nil prop The created prop entity, or nil if it failed
 local function createPropOnBone(ped, modelName, boneId, coords, rotation)
     local model = joaat(modelName)
+
+    if not IsModelValid(model) then
+        warn(('Attempted to load invalid model: %s'):format(modelName))
+        return nil
+    end
+
     local loaded = lib.waitFor(function()
         RequestModel(model)
         if HasModelLoaded(model) then return true end

--- a/client/main.lua
+++ b/client/main.lua
@@ -8,19 +8,27 @@ local function toggleLock(vehicle)
     if vehicleConfig.noLock or vehicleConfig.shared then return end
     if GetIsVehicleAccessible(vehicle) then
 
-        lib.playAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3.0, 3.0, -1, 49)
+        local propModel = joaat('m23_2_prop_m32_carkey_fob_01a')
+        RequestModel(propModel)
+        while not HasModelLoaded(propModel) do Wait(0) end
 
-        --- if the statebag is out of sync, rely on it as the source of truth and sync the client to the statebag's value
+        local prop = CreateObject(propModel, 0, 0, 0, true, true, false)
+        while not DoesEntityExist(prop) do Wait(0) end
+
+        AttachEntityToEntity(
+            prop, cache.ped,
+            GetPedBoneIndex(cache.ped, 57005), 0.12, 0.04, 0.0, 27.42, 180.8, 176.34, true, true, false, true, 1, true)
+
+        lib.playAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3.0, 3.0, -1, 49)
+		
+		--- if the statebag is out of sync, rely on it as the source of truth and sync the client to the statebag's value
         local stateBagValue = Entity(vehicle).state.doorslockstate
         if GetVehicleDoorLockStatus(vehicle) ~= stateBagValue then
             SetVehicleDoorsLocked(vehicle, stateBagValue)
         end
-
         local lockstate = (GetVehicleDoorLockStatus(vehicle) % 2) + 1
-
         TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(vehicle), lockstate)
         exports.qbx_core:Notify(locale(lockstate == 2 and 'notify.vehicle_locked' or 'notify.vehicle_unlocked'))
-
         qbx.playAudio({ audioName = 'Remote_Control_Fob', audioRef = 'PI_Menu_Sounds', source = vehicle })
         SetVehicleLights(vehicle, 2)
         Wait(250)
@@ -29,6 +37,9 @@ local function toggleLock(vehicle)
         SetVehicleLights(vehicle, 0)
         Wait(300)
         ClearPedTasks(cache.ped)
+
+        DeleteObject(prop)
+        SetModelAsNoLongerNeeded(propModel)
     else
         exports.qbx_core:Notify(locale('notify.no_keys'), 'error')
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -59,7 +59,7 @@ local function toggleLock(vehicle)
         local prop = createPropOnBone(
             cache.ped,
             'm23_2_prop_m32_carkey_fob_01a', -- prop model
-            57005, -- player bone
+            57005, -- player bone (animation uses right hand)
             vector3(0.12, 0.04, 0.0), -- coords
             vector3(27.42, 180.8, 176.34) -- rotation
         )

--- a/client/main.lua
+++ b/client/main.lua
@@ -52,12 +52,14 @@ local function toggleLock(vehicle)
     if GetIsVehicleAccessible(vehicle) then
         local prop = createPropOnBone(
             cache.ped,
-            'm23_2_prop_m32_carkey_fob_01a',
-            57005,
-            vector3(0.12, 0.04, 0.0),
-            vector3(27.42, 180.8, 176.34)
+            'm23_2_prop_m32_carkey_fob_01a', -- prop model
+            57005, -- player bone
+            vector3(0.12, 0.04, 0.0), -- coords
+            vector3(27.42, 180.8, 176.34) -- rotation
         )
+
         lib.playAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3.0, 3.0, -1, 49)
+
         local stateBagValue = Entity(vehicle).state.doorslockstate
         if GetVehicleDoorLockStatus(vehicle) ~= stateBagValue then
             SetVehicleDoorsLocked(vehicle, stateBagValue)
@@ -72,7 +74,9 @@ local function toggleLock(vehicle)
         Wait(200)
         SetVehicleLights(vehicle, 0)
         Wait(300)
+
         ClearPedTasks(cache.ped)
+
         if prop then
             DeleteObject(prop)
         end

--- a/client/main.lua
+++ b/client/main.lua
@@ -66,13 +66,17 @@ local function toggleLock(vehicle)
 
         lib.playAnim(cache.ped, 'anim@mp_player_intmenu@key_fob@', 'fob_click', 3.0, 3.0, -1, 49)
 
+        --- if the statebag is out of sync, rely on it as the source of truth and sync the client to the statebag's value
         local stateBagValue = Entity(vehicle).state.doorslockstate
         if GetVehicleDoorLockStatus(vehicle) ~= stateBagValue then
             SetVehicleDoorsLocked(vehicle, stateBagValue)
         end
+        
         local lockstate = (GetVehicleDoorLockStatus(vehicle) % 2) + 1
+        
         TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(vehicle), lockstate)
         exports.qbx_core:Notify(locale(lockstate == 2 and 'notify.vehicle_locked' or 'notify.vehicle_unlocked'))
+        
         qbx.playAudio({ audioName = 'Remote_Control_Fob', audioRef = 'PI_Menu_Sounds', source = vehicle })
         SetVehicleLights(vehicle, 2)
         Wait(250)
@@ -80,7 +84,6 @@ local function toggleLock(vehicle)
         Wait(200)
         SetVehicleLights(vehicle, 0)
         Wait(300)
-
         ClearPedTasks(cache.ped)
 
         if prop then


### PR DESCRIPTION
## Description
Adding keyfob prop to lock/unlock animation to complete this request: https://github.com/Qbox-project/qbx_vehiclekeys/issues/166

https://youtu.be/2bVHwTcrOlk

Only thing i'm not 100% sure on is prop compatability across FiveM build versions that servers may run. I assume this prop is available across the current builds. I guess the only risk is that the prop just doesn't spawn, which isn't a biggie.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
