### PR TITLE
fix(sharedKeys): correct AreKeysJobShared behavior for nil and off-duty states

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -2,15 +2,33 @@ local config = require 'config.client'
 
 ---Grants keys for job shared vehicles
 ---@param vehicle number The entity number of the vehicle.
----@return boolean? `true` if the vehicle is shared for a player's job, `nil` otherwise.
+---@return boolean? `true` if the vehicle is shared for the player's current job, `nil` if the player has no job or is off duty.
 function AreKeysJobShared(vehicle)
-    local job = QBX.PlayerData.job.name
-    local jobInfo = config.sharedKeys[job]
+    local job = QBX.PlayerData.job
+    if not job then return end
+    local jobName = job.name
+    local jobProfile = config.sharedKeys[jobName]
+    if not jobProfile then return end
 
-    if not jobInfo or (jobInfo.requireOnDuty and not QBX.PlayerData.job.onduty) then return end
+    assert(
+        jobProfile.classes or jobProfile.vehicles,
+        string.format(
+            'Vehicles not configured for the %s job.',
+            jobName
+        )
+    )
 
-    assert(jobInfo.vehicles, string.format('Vehicles not configured for the %s job.', job))
-    return jobInfo.vehicles and jobInfo.vehicles[GetEntityModel(vehicle)] or jobInfo.classes and jobInfo.classes[GetVehicleClass(vehicle)]
+    if jobProfile.requireOnDuty and not QBX.PlayerData.job.onduty then
+        exports.qbx_core:Notify(locale('notify.require_on_duty'), 'error')
+        return
+    end
+
+    local isSharedVehicleClass = jobProfile.classes
+        and jobProfile.classes[GetVehicleClass(vehicle)]
+
+    return isSharedVehicleClass
+        or (jobProfile.vehicles
+       and jobProfile.vehicles[GetEntityModel(vehicle)])
 end
 
 ---Checks if player has vehicle keys

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 
 description 'vehicle key management system'
 repository 'https://github.com/Qbox-project/qbx_vehiclekeys'
-version '1.0.2'
+version '1.0.3'
 
 ox_lib 'locale'
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -45,7 +45,8 @@
     "removed_keys_player": "Your keys to plate %s have been removed!",
     "player_offline": "This player is not online!",
 	  "vehicle_is_unlocked": "Vehicle is already unlocked!",
-    "not_optin": "You are not opted in for admin duty. (/optin to toggle)"
+    "not_optin": "You are not opted in for admin duty. (/optin to toggle)",
+    "require_on_duty": "This vehicle is restricted to on-duty personnel only."
   },
   "progress": {
     "attempting_carjack": "Attempting Carjacking...",


### PR DESCRIPTION
## Description

This update improves how `AreKeysJobShared` behaves in a few important situations. The function now catches misconfigured job entries more reliably, shows a clear notification when a player is off duty, and handles several edge cases that the previous version didn’t cover well (QBX.PlayerData.job may be nil).

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
