### PR TITLE
feat(autolock): move autolock and sharedKeys validation to separate module

### DIFF
--- a/client/autolock.lua
+++ b/client/autolock.lua
@@ -1,0 +1,31 @@
+local config = require 'config.client'
+
+if not config.sharedKeys then return end -- No need to run the module if there are no shared key profiles
+
+-- Ensure shared keys config is valid
+for name, info in pairs(config.sharedKeys) do
+    assert(
+        info.vehicles or info.classes,
+        ("Profile for job '%s' must have either a vehicles or classes field defined."):format(name)
+    )
+end
+
+local isAutolockEnabled = false
+local autolockProfiles = {}
+for job, info in pairs(config.sharedKeys) do
+    if info.enableAutolock then
+        autolockProfiles[job] = info
+        isAutolockEnabled = true
+    end
+end
+
+if not isAutolockEnabled then return end -- No need to run this code if autolock isn't enabled
+
+lib.onCache('vehicle', function (vehicle, leftVehicle)
+    if not vehicle and leftVehicle and DoesEntityExist(leftVehicle) then
+        local jobProfile = autolockProfiles[QBX.PlayerData.job.name]
+        if jobProfile and AreKeysJobShared(leftVehicle, true) then
+            TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(leftVehicle), 2)
+        end
+    end
+end)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -1,25 +1,20 @@
 local config = require 'config.client'
 
----Grants keys for job shared vehicles
+--- Checks if the vehicle is shared for the player's current job and if the player meets the requirements to use shared keys.
 ---@param vehicle number The entity number of the vehicle.
+---@param skipNotification? boolean
 ---@return boolean? `true` if the vehicle is shared for the player's current job, `nil` if the player has no job or is off duty.
-function AreKeysJobShared(vehicle)
+function AreKeysJobShared(vehicle, skipNotification)
+    if not config.sharedKeys then return end
     local job = QBX.PlayerData.job
     if not job then return end
-    local jobName = job.name
-    local jobProfile = config.sharedKeys[jobName]
+    local jobProfile = config.sharedKeys[job.name]
     if not jobProfile then return end
 
-    assert(
-        jobProfile.classes or jobProfile.vehicles,
-        string.format(
-            'Vehicles not configured for the %s job.',
-            jobName
-        )
-    )
-
-    if jobProfile.requireOnDuty and not QBX.PlayerData.job.onduty then
-        exports.qbx_core:Notify(locale('notify.require_on_duty'), 'error')
+    if jobProfile.requireOnDuty and not job.onduty then
+        if not skipNotification then
+            exports.qbx_core:Notify(locale('notify.require_on_duty'), 'error')
+        end
         return
     end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -206,23 +206,6 @@ RegisterNetEvent('qbx_vehiclekeys:client:OnLostKeys', function()
     end
 end)
 
-for _, info in pairs(config.sharedKeys) do
-    if info.enableAutolock then
-        lib.onCache('vehicle', function (vehicle)
-            local leftVehicle = cache.vehicle
-            if not vehicle and leftVehicle then
-                local isShared = AreKeysJobShared(leftVehicle)
-                local isAutolockEnabled = config.sharedKeys[QBX.PlayerData.job.name]?.enableAutolock
-
-                if isShared and isAutolockEnabled then
-                    TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(leftVehicle), 2)
-                end
-            end
-        end)
-        break
-    end
-end
-
 qbx.entityStateHandler('doorslockstate', function(entity, _, value)
     if entity == 0 then return end
     SetVehicleDoorsLocked(entity, value)

--- a/config/client.lua
+++ b/config/client.lua
@@ -68,7 +68,7 @@ return {
     sharedKeys = { -- Share keys amongst employees. Employees can lock/unlock any job-listed vehicle
         police = { -- Job name
             enableAutolock = true,
-            requireOnduty = true,
+            requireOnDuty = true,
             classes = {},
             vehicles = {
                 [`police`] = true,  -- Vehicle model
@@ -77,14 +77,14 @@ return {
         },
         ambulance = {
             enableAutolock = true,
-            requireOnduty = true,
+            requireOnDuty = true,
             classes = {},
             vehicles = {
                 [`ambulance`] = true,
             },
         },
         mechanic = {
-            requireOnduty = false,
+            requireOnDuty = false,
             vehicles = {
                 [`towtruck`] = true,
             }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,6 +20,7 @@ client_scripts {
     'client/functions.lua',
     'client/searchkeys.lua',
     'client/main.lua',
+    'client/autolock.lua',
     'client/carjack.lua',
     'bridge/qb/client.lua',
 }


### PR DESCRIPTION
## Description

- Move autolock into its own file and make job-shared key checks safer;
- Make `AreKeysJobShared` return early if `config.sharedKeys` is missing;
- Fix a typo in `client.lua` (change `requireonDuty` to `requireOnDuty`);
- Add a `skipNotification` parameter to `AreKeysJobShared` for the autolock case.
- Move the shared key configuration validator to initialization.

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
