### PR TITLE
fix: secure server-side key-grant events against netId spoofing

### DIFF
--- a/bridge/qb/server.lua
+++ b/bridge/qb/server.lua
@@ -1,11 +1,14 @@
 if GetConvar('qbx_vehiclekeys:enableBridge', 'true') ~= 'true' then return end
 
-local function giveKeys(source, plate)
+---@param source number ID of the player
+---@param plate? string
+---@param enforceProximity? boolean When true (client-triggered path), only grant keys to vehicles the player is actually next to.
+local function giveKeys(source, plate, enforceProximity)
     local vehicles = plate and GetVehiclesFromPlate(plate) or {GetVehiclePedIsIn(GetPlayerPed(source), false)}
     local success = false
     for i = 1, #vehicles do
         local vehicle = vehicles[i]
-        if DoesEntityExist(vehicle) then
+        if DoesEntityExist(vehicle) and (not enforceProximity or IsPlayerNearVehicle(source, vehicle)) then
             if GiveKeys(source, vehicles[i], true) then
                 success = true
             end
@@ -41,7 +44,7 @@ end
 CreateQbExport('RemoveKeys', removeKeys)
 
 RegisterNetEvent('qb-vehiclekeys:server:AcquireVehicleKeys', function(plate)
-    giveKeys(source, plate)
+    giveKeys(source, plate, true)
 end)
 
 RegisterNetEvent('qb-vehiclekeys:server:removeKeys', function(plate)

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,6 +1,7 @@
 return {
     runClearCronMinutes = 5,
     distanceToHandKeys = 3,
+    distanceToVehicle = 7.5,             -- Max distance (m) between a player and a vehicle for server-side key-grant events to be honored. Prevents granting keys to vehicles the player isn't actually next to.
     ---@type table<WeaponTypeGroup, number>
     carjackChance = {                    -- Probability of successful carjacking based on weapon used
         [WeaponTypeGroup.MELEE] = 0.0,

--- a/server/keys.lua
+++ b/server/keys.lua
@@ -128,8 +128,25 @@ end
 
 exports('HasKeys', HasKeys)
 
+---Checks whether the player's ped is close enough to a vehicle to legitimately request keys for it.
+---Server-side key-grant events are triggered by the client, so without this check a player could
+---grant themselves keys to any vehicle on the server by spoofing its network id.
+---@param source number ID of the player
+---@param vehicle number
+---@return boolean
+function IsPlayerNearVehicle(source, vehicle)
+    if not vehicle or vehicle == 0 or not DoesEntityExist(vehicle) then return false end
+    local ped = GetPlayerPed(source)
+    if ped == 0 then return false end
+    return #(GetEntityCoords(ped) - GetEntityCoords(vehicle)) <= config.distanceToVehicle
+end
+
+exports('IsPlayerNearVehicle', IsPlayerNearVehicle)
+
 lib.callback.register('qbx_vehiclekeys:server:giveKeys', function(source, netId)
-    GiveKeys(source, NetworkGetEntityFromNetworkId(netId))
+    local vehicle = NetworkGetEntityFromNetworkId(netId)
+    if not IsPlayerNearVehicle(source, vehicle) then return end
+    GiveKeys(source, vehicle)
 end)
 
 AddStateBagChangeHandler('vehicleid', '', function(bagName, _, vehicleId)

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,6 +12,7 @@ exports('SetLockState', setLockState)
 
 lib.callback.register('qbx_vehiclekeys:server:findKeys', function(source, netId)
     local vehicle = NetworkGetEntityFromNetworkId(netId)
+    if not IsPlayerNearVehicle(source, vehicle) then return end
     if math.random() <= GetVehicleConfig(vehicle).findKeysChance then
         GiveKeys(source, vehicle)
         return true
@@ -19,9 +20,10 @@ lib.callback.register('qbx_vehiclekeys:server:findKeys', function(source, netId)
 end)
 
 lib.callback.register('qbx_vehiclekeys:server:carjack', function(source, netId, weaponTypeGroup)
+    local vehicle = NetworkGetEntityFromNetworkId(netId)
+    if not IsPlayerNearVehicle(source, vehicle) then return end
     local chance = config.carjackChance[weaponTypeGroup] or 0.5
     if math.random() <= chance then
-        local vehicle = NetworkGetEntityFromNetworkId(netId)
         GiveKeys(source, vehicle)
         setLockState(vehicle, 'unlock')
         return true
@@ -31,18 +33,23 @@ end)
 RegisterNetEvent('qbx_vehiclekeys:server:playerEnteredVehicleWithEngineOn', function(netId)
     local src = source
     local vehicle = NetworkGetEntityFromNetworkId(netId)
+    if not IsPlayerNearVehicle(src, vehicle) then return end
     if not GetIsVehicleEngineRunning(vehicle) then return end
     GiveKeys(src, vehicle)
 end)
 
----TODO: secure this event
 RegisterNetEvent('qbx_vehiclekeys:server:tookKeys', function(netId)
-    GiveKeys(source, NetworkGetEntityFromNetworkId(netId))
+    local src = source
+    local vehicle = NetworkGetEntityFromNetworkId(netId)
+    if not IsPlayerNearVehicle(src, vehicle) then return end
+    GiveKeys(src, vehicle)
 end)
 
----TODO: secure this event
 RegisterNetEvent('qbx_vehiclekeys:server:hotwiredVehicle', function(netId)
-    GiveKeys(source, NetworkGetEntityFromNetworkId(netId))
+    local src = source
+    local vehicle = NetworkGetEntityFromNetworkId(netId)
+    if not IsPlayerNearVehicle(src, vehicle) then return end
+    GiveKeys(src, vehicle)
 end)
 
 RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)


### PR DESCRIPTION
## Description

Several server-side key-grant entrypoints granted keys for whatever vehicle a client-supplied network id resolved to, without verifying the requesting player was actually near that vehicle:

- the `qbx_vehiclekeys:server:findKeys`, `:carjack` and `:giveKeys` callbacks
- the `qbx_vehiclekeys:server:playerEnteredVehicleWithEngineOn` event
- `qbx_vehiclekeys:server:tookKeys` and `:hotwiredVehicle` (the two `---TODO: secure this event` markers)
- the qb bridge `qb-vehiclekeys:server:AcquireVehicleKeys` event

Because these are triggered by the client, a player could spoof any network id (or, through the bridge, a plate) and grant themselves keys to any vehicle on the server.

This adds `IsPlayerNearVehicle(source, vehicle)` and gates every client-triggered grant on it. The trusted server-side `GiveKeys` export is left unchanged, so resources that hand out keys on spawn keep working; only the client-facing bridge event enforces proximity. The threshold is configurable via `config.distanceToVehicle` (default `7.5`), and the helper also doubles as a `DoesEntityExist` guard against invalid network ids.

The separate `GetVehiclesFromPlate` plate-matching bug is intentionally left out of this PR (it's handled by #173); `bridge/qb/shared.lua` is untouched to avoid conflicts.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
