### PR TITLE
Fix requireOnDuty config typo

### DIFF
--- a/config/client.lua
+++ b/config/client.lua
@@ -68,7 +68,7 @@ return {
     sharedKeys = { -- Share keys amongst employees. Employees can lock/unlock any job-listed vehicle
         police = { -- Job name
             enableAutolock = true,
-            requireOnduty = true,
+            requireOnDuty = true,
             classes = {},
             vehicles = {
                 [`police`] = true,  -- Vehicle model
@@ -77,14 +77,14 @@ return {
         },
         ambulance = {
             enableAutolock = true,
-            requireOnduty = true,
+            requireOnDuty = true,
             classes = {},
             vehicles = {
                 [`ambulance`] = true,
             },
         },
         mechanic = {
-            requireOnduty = false,
+            requireOnDuty = false,
             vehicles = {
                 [`towtruck`] = true,
             }


### PR DESCRIPTION
## Description

Fixes a typo in the `sharedKeys` config examples.

`client/functions.lua` checks `jobProfile.requireOnDuty`, but the sample job configs in `config/client.lua` used `requireOnduty`. Since Lua table keys are case-sensitive, the on-duty requirement was not being applied for those shared vehicle entries.

This PR updates the config keys for `police`, `ambulance`, and `mechanic` to use `requireOnDuty`, matching the field the code already reads.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.