### PR TITLE
fix: validate vehicle lock state requests

### DIFF
--- a/client/carjack.lua
+++ b/client/carjack.lua
@@ -109,7 +109,7 @@ end
 ---@param weaponHash number The current weapon hash.
 ---@return boolean `true` if the weapon cannot be used to carjacking, `false` otherwise.
 local function getIsBlacklistedWeapon(weaponHash)
-    return qbx.array.contains(config.noCarjackWeapons, weaponHash)
+    return lib.table.contains(config.noCarjackWeapons, weaponHash)
 end
 
 local isWatchCarjackingAttemptRunning = false

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,6 +1,7 @@
 return {
     runClearCronMinutes = 5,
     distanceToHandKeys = 3,
+    distanceToVehicle = 7.5,             -- Max distance (m) between a player and a vehicle for server-side key-grant events to be honored. Prevents granting keys to vehicles the player isn't actually next to.
     ---@type table<WeaponTypeGroup, number>
     carjackChance = {                    -- Probability of successful carjacking based on weapon used
         [WeaponTypeGroup.MELEE] = 0.0,

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,17 @@
 local config = require 'config.server'
+local lockStateCooldown = {}
+
+local function canSetLockState(source, vehicle)
+    if not vehicle or vehicle == 0 or not DoesEntityExist(vehicle) or GetEntityType(vehicle) ~= 2 then return false end
+
+    local ped = GetPlayerPed(source)
+    if ped == 0 or #(GetEntityCoords(ped) - GetEntityCoords(vehicle)) > config.distanceToVehicle then return false end
+
+    local now = GetGameTimer()
+    if lockStateCooldown[source] and now - lockStateCooldown[source] < 500 then return false end
+    lockStateCooldown[source] = now
+    return true
+end
 
 ---@param veh number
 ---@param state string
@@ -51,8 +64,13 @@ RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
 end)
 
 RegisterNetEvent('qb-vehiclekeys:server:setVehLockState', function(netId, state)
+    local src = source
     local vehicle = NetworkGetEntityFromNetworkId(netId)
-	if type(state) ~= 'number' or not DoesEntityExist(vehicle) then return end
+	if (state ~= 1 and state ~= 2) or not canSetLockState(src, vehicle) then return end
     if state == 2 then state = 'lock' else state = 'unlock' end
 	setLockState(vehicle, state)
+end)
+
+AddEventHandler('playerDropped', function()
+    lockStateCooldown[source] = nil
 end)


### PR DESCRIPTION
## Summary

- reject lock-state values outside the supported locked/unlocked states
- verify the requested network entity is an existing vehicle near the caller
- rate-limit lock-state mutation requests per player
- clear request state when a player disconnects

## Security impact

Clients can currently set the replicated lock state of any networked vehicle by submitting its network ID. This bounds the event to nearby vehicle interactions and prevents high-rate remote lock-state manipulation.

This complements #190, which applies the same server-side distance setting to key-grant events. The identical config addition is intentional so the branches consolidate cleanly whichever lands first.

## Validation

- `git diff --check`
- direct review of the key-fob, autolock, initial-lock, and lockpick call paths
- GitHub lint and security checks will run on this draft